### PR TITLE
feature: CI-based CDK devnets with integration tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Run Regression Tests
-        uses: 0xPolygon/kurtosis-cdk@v0.1.8
+        uses: 0xPolygon/kurtosis-cdk@v0.1.9
         with:
           zkevm_agglayer: ${{ github.event.inputs.zkevm_agglayer }}
           zkevm_bridge_service: ${{ github.event.inputs.zkevm_bridge_service }}


### PR DESCRIPTION
## Description

add the following features:
- a github actions workflow that allows cdk eng teams to create and test CDK devnets in less <20min
- cdk eng team can custom-specify the exact commit id OR existing release tag of any upstream CDK repo, and create JIT devnet on the fly using this new github action
- users get a clear go/no-go CI check whether the devnet is behaving as expected (i.e. verifiedBatchNumber is incrementing) and can withstand a series of transactions load tests (via polycli) 

## How Has This Been Tested?

Fully here, e2e devent workflow and cdk integration tests all working as expected: 
- https://github.com/rebelArtists/agglayer/actions/runs/8832585130/job/24250186705

## Screenshots (if appropriate):
<img width="250" alt="image" src="https://github.com/0xPolygon/cdk/assets/100106211/d7f60fb3-9aea-4c30-98dc-adaa570df6f1">
<img width="983" alt="image" src="https://github.com/0xPolygon/cdk/assets/100106211/b2107df0-5d02-4fde-88d5-908fed4ee4b6">
<img width="1435" alt="image" src="https://github.com/0xPolygon/cdk/assets/100106211/e42aa590-8c06-4d47-9044-bb394be6a71d">
<img width="1427" alt="image" src="https://github.com/0xPolygon/cdk/assets/100106211/57bbb5e6-e8cb-4f37-a045-015b78a80dc6">


## Additional context

devTools jira ticket: [DVT-1464](https://polygon.atlassian.net/browse/DVT-1464)


[DVT-1464]: https://polygon.atlassian.net/browse/DVT-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ