### PR TITLE
feat: add syncOnlyMode to aggregator

### DIFF
--- a/aggregator/config.go
+++ b/aggregator/config.go
@@ -151,6 +151,10 @@ type Config struct {
 
 	// MaxWitnessRetrievalWorkers is the maximum number of workers that will be used to retrieve the witness
 	MaxWitnessRetrievalWorkers int `mapstructure:"MaxWitnessRetrievalWorkers"`
+
+	// SyncModeOnlyEnabled is a flag to enable the sync mode only
+	// In this mode the aggregator will only sync from L1 and will not generate or read the data stream
+	SyncModeOnlyEnabled bool `mapstructure:"SyncModeOnlyEnabled"`
 }
 
 // StreamClientCfg contains the data streamer's configuration properties

--- a/config/default.go
+++ b/config/default.go
@@ -70,6 +70,7 @@ SettlementBackend = "l1"
 AggLayerTxTimeout = "5m"
 AggLayerURL = ""
 MaxWitnessRetrievalWorkers = 2
+SyncModeOnlyEnabled = false
 SequencerPrivateKey = {}
 	[Aggregator.DB]
 		Name = "aggregator_db"

--- a/test/config/test.config.toml
+++ b/test/config/test.config.toml
@@ -56,8 +56,10 @@ UseL1BatchData = true
 SettlementBackend = "l1"
 AggLayerTxTimeout = "5m"
 AggLayerURL = ""
-SequencerPrivateKey = {}
+MaxWitnessRetrievalWorkers = 2
+SyncModeOnlyEnabled = false
 UseFullWitness = false
+SequencerPrivateKey = {}
 	[Aggregator.DB]
 		Name = "aggregator_db"
 		User = "aggregator_user"

--- a/test/config/test.kurtosis_template.toml
+++ b/test/config/test.kurtosis_template.toml
@@ -69,6 +69,9 @@ UseFullWitness = false
 SettlementBackend = "l1"
 AggLayerTxTimeout = "5m"
 AggLayerURL = ""
+MaxWitnessRetrievalWorkers = 2
+SyncModeOnlyEnabled = false
+UseFullWitness = false
 SequencerPrivateKey = {}
 	[Aggregator.DB]
 		Name = "aggregator_db"


### PR DESCRIPTION
## Description

Adds syncOnlyMode to aggregator.  This allows syncing networks from L1 before really deploying the aggregator in those chains. 