### PR TITLE
fix: build Go bin for the correct platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CONTAINER FOR BUILDING BINARY
-FROM golang:1.22.4 AS build
+FROM --platform=${BUILDPLATFORM} golang:1.22.4 AS build
 
 WORKDIR $GOPATH/src/github.com/0xPolygon/cdk
 


### PR DESCRIPTION
## Description

Fix multiplatform build of Go bin in Docker
