### PR TITLE
fix: CodeQL Github workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         language:
           - go
-          - bash
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

The PR fixes the custom CodeQL GH workflow file, because previously it was failing due to the wrong CRON variable.