### PR TITLE
feat: seq sender sanity check l1infotree

### DIFF
--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -1168,7 +1168,8 @@ func (s *SequenceSender) addInfoSequenceBatchEnd(batch *datastream.BatchEnd) {
 // addNewBatchL2Block adds a new L2 block to the work in progress batch
 func (s *SequenceSender) addNewBatchL2Block(l2Block *datastream.L2Block) {
 	s.mutexSequence.Lock()
-	s.logger.Infof(".....new L2 block, number %d (batch %d)", l2Block.Number, l2Block.BatchNumber)
+	s.logger.Infof(".....new L2 block, number %d (batch %d) l1infotree %d",
+		l2Block.Number, l2Block.BatchNumber, l2Block.L1InfotreeIndex)
 
 	// Current batch
 	data := s.sequenceData[s.wipBatch]
@@ -1183,7 +1184,11 @@ func (s *SequenceSender) addNewBatchL2Block(l2Block *datastream.L2Block) {
 			)
 		}
 		data.batch.SetLastCoinbase(common.BytesToAddress(l2Block.Coinbase))
-		data.batch.SetL1InfoTreeIndex(l2Block.L1InfotreeIndex)
+		if l2Block.L1InfotreeIndex != 0 {
+			data.batch.SetL1InfoTreeIndex(l2Block.L1InfotreeIndex)
+		} else {
+			s.logger.Warnf("L1InfotreeIndex is 0, we don't change batch L1InfotreeIndex (%d)", data.batch.L1InfoTreeIndex())
+		}
 		// New L2 block raw
 		newBlockRaw := state.L2BlockRaw{}
 

--- a/sequencesender/txbuilder/banana_base.go
+++ b/sequencesender/txbuilder/banana_base.go
@@ -134,8 +134,24 @@ func (t *TxBuilderBananaBase) NewSequence(
 
 	sequence.OldAccInputHash = oldAccInputHash
 	sequence.AccInputHash = accInputHash
+
+	err = SequenceSanityCheck(sequence)
+	if err != nil {
+		return nil, fmt.Errorf("sequenceSanityCheck fails. Err: %w", err)
+	}
 	res := NewBananaSequence(*sequence)
 	return res, nil
+}
+
+func SequenceSanityCheck(seq *etherman.SequenceBanana) error {
+	maxL1InfoIndex, err := CalculateMaxL1InfoTreeIndexInsideSequence(seq)
+	if err != nil {
+		return err
+	}
+	if seq.CounterL1InfoRoot < maxL1InfoIndex+1 {
+		return fmt.Errorf("wrong CounterL1InfoRoot(%d): BatchL2Data (max=%d) ", seq.CounterL1InfoRoot, maxL1InfoIndex)
+	}
+	return nil
 }
 
 func (t *TxBuilderBananaBase) getL1InfoRoot(counterL1InfoRoot uint32) (common.Hash, error) {

--- a/sequencesender/txbuilder/banana_base.go
+++ b/sequencesender/txbuilder/banana_base.go
@@ -144,7 +144,7 @@ func (t *TxBuilderBananaBase) NewSequence(
 }
 
 func SequenceSanityCheck(seq *etherman.SequenceBanana) error {
-	maxL1InfoIndex, err := CalculateMaxL1InfoTreeIndexInsideSequence(seq)
+	maxL1InfoIndex, err := calculateMaxL1InfoTreeIndexInsideSequence(seq)
 	if err != nil {
 		return err
 	}

--- a/sequencesender/txbuilder/banana_base_test.go
+++ b/sequencesender/txbuilder/banana_base_test.go
@@ -2,6 +2,7 @@ package txbuilder_test
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -33,8 +34,15 @@ func TestBananaBaseNewSequenceEmpty(t *testing.T) {
 	seq, err := testData.sut.NewSequence(context.TODO(), nil, common.Address{})
 	require.NotNil(t, seq)
 	require.NoError(t, err)
-	// TODO check values
-	// require.Equal(t, lastAcc, seq.LastAccInputHash())
+}
+
+func TestBananaBaseNewSequenceErrorHeaderByNumber(t *testing.T) {
+	testData := newBananaBaseTestData(t)
+	testData.l1Client.On("HeaderByNumber", mock.Anything, mock.Anything).
+		Return(nil, fmt.Errorf("error"))
+	seq, err := testData.sut.NewSequence(context.TODO(), nil, common.Address{})
+	require.Nil(t, seq)
+	require.Error(t, err)
 }
 
 func TestBananaBaseNewBatchFromL2Block(t *testing.T) {
@@ -109,6 +117,11 @@ func TestBananaSanityCheck(t *testing.T) {
 	seq.CounterL1InfoRoot = 1
 	err = txbuilder.SequenceSanityCheck(&seq)
 	require.Error(t, err, "inside batchl2data max is 1 and counter is 1. The batchl2data is not included in counter")
+}
+
+func TestBananaSanityCheckNilSeq(t *testing.T) {
+	err := txbuilder.SequenceSanityCheck(nil)
+	require.Error(t, err, "nil sequence")
 }
 
 type testDataBananaBase struct {

--- a/sequencesender/txbuilder/banana_base_test.go
+++ b/sequencesender/txbuilder/banana_base_test.go
@@ -5,11 +5,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/cdk/etherman"
 	"github.com/0xPolygon/cdk/l1infotreesync"
 	"github.com/0xPolygon/cdk/log"
 	"github.com/0xPolygon/cdk/sequencesender/seqsendertypes"
 	"github.com/0xPolygon/cdk/sequencesender/txbuilder"
 	"github.com/0xPolygon/cdk/sequencesender/txbuilder/mocks_txbuilder"
+	"github.com/0xPolygon/cdk/state"
 	"github.com/0xPolygon/cdk/state/datastream"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -77,6 +79,36 @@ func TestBananaBaseNewSequenceBatch(t *testing.T) {
 	require.NotNil(t, seq)
 	require.NoError(t, err)
 	// TODO: check that the seq have the right values
+}
+
+func TestBananaSanityCheck(t *testing.T) {
+	batch := state.BatchRawV2{
+		Blocks: []state.L2BlockRaw{
+			{
+				BlockNumber: 1,
+				ChangeL2BlockHeader: state.ChangeL2BlockHeader{
+					DeltaTimestamp:  1,
+					IndexL1InfoTree: 1,
+				},
+			},
+		},
+	}
+	data, err := state.EncodeBatchV2(&batch)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	seq := etherman.SequenceBanana{
+		CounterL1InfoRoot: 2,
+		Batches: []etherman.Batch{
+			{
+				L2Data: data,
+			},
+		},
+	}
+	err = txbuilder.SequenceSanityCheck(&seq)
+	require.NoError(t, err, "inside batchl2data max is 1 and counter is 2 (2>=1+1)")
+	seq.CounterL1InfoRoot = 1
+	err = txbuilder.SequenceSanityCheck(&seq)
+	require.Error(t, err, "inside batchl2data max is 1 and counter is 1. The batchl2data is not included in counter")
 }
 
 type testDataBananaBase struct {

--- a/sequencesender/txbuilder/banana_types.go
+++ b/sequencesender/txbuilder/banana_types.go
@@ -149,29 +149,32 @@ func (b *BananaSequence) SetLastVirtualBatchNumber(batchNumber uint64) {
 	b.SequenceBanana.LastVirtualBatchNumber = batchNumber
 }
 
-func CalculateMaxL1InfoTreeIndexInsideL2Data(l2data []byte) (uint32, error) {
+func calculateMaxL1InfoTreeIndexInsideL2Data(l2data []byte) (uint32, error) {
 	batchRawV2, err := state.DecodeBatchV2(l2data)
 	if err != nil {
-		return 0, fmt.Errorf("CalculateMaxL1InfoTreeIndexInsideL2Data: error decoding batchL2Data, err:%w", err)
+		return 0, fmt.Errorf("calculateMaxL1InfoTreeIndexInsideL2Data: error decoding batchL2Data, err:%w", err)
 	}
 	if batchRawV2 == nil {
-		return 0, fmt.Errorf("CalculateMaxL1InfoTreeIndexInsideL2Data: batchRawV2 is nil")
+		return 0, fmt.Errorf("calculateMaxL1InfoTreeIndexInsideL2Data: batchRawV2 is nil")
 	}
 	maxIndex := uint32(0)
-	for i := range batchRawV2.Blocks {
-		if batchRawV2.Blocks[i].IndexL1InfoTree > maxIndex {
-			maxIndex = batchRawV2.Blocks[i].IndexL1InfoTree
+	for _, block := range batchRawV2.Blocks {
+		if block.IndexL1InfoTree > maxIndex {
+			maxIndex = block.IndexL1InfoTree
 		}
 	}
 	return maxIndex, nil
 }
 
-func CalculateMaxL1InfoTreeIndexInsideSequence(seq *etherman.SequenceBanana) (uint32, error) {
+func calculateMaxL1InfoTreeIndexInsideSequence(seq *etherman.SequenceBanana) (uint32, error) {
+	if seq == nil {
+		return 0, fmt.Errorf("calculateMaxL1InfoTreeIndexInsideSequence: seq is nil")
+	}
 	maxIndex := uint32(0)
 	for _, batch := range seq.Batches {
-		index, err := CalculateMaxL1InfoTreeIndexInsideL2Data(batch.L2Data)
+		index, err := calculateMaxL1InfoTreeIndexInsideL2Data(batch.L2Data)
 		if err != nil {
-			return 0, fmt.Errorf("CalculateMaxL1InfoTreeIndexInsideBatches: error getting batch L1InfoTree , err:%w", err)
+			return 0, fmt.Errorf("calculateMaxL1InfoTreeIndexInsideBatches: error getting batch L1InfoTree , err:%w", err)
 		}
 		if index > maxIndex {
 			maxIndex = index


### PR DESCRIPTION
## Description

When a sequence is build it checks that the L1InfoTreeCount set include the indexes inside batchL2data of all batches conforming the sequence