### PR TITLE
ci: pin kurtosis-cdk version in tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,6 +66,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: "kurtosis-cdk"
+        ref: "v0.2.11"
 
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0


### PR DESCRIPTION
This will ensure ci is deterministic while using the same version.