### PR TITLE
fix: aggregator sync multi seqbatches same block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/0xPolygon/cdk-rpc v0.0.0-20240905074455-431d3c271fe8
 	github.com/0xPolygonHermez/zkevm-data-streamer v0.2.6
 	github.com/0xPolygonHermez/zkevm-ethtx-manager v0.1.10-0.20240930120324-65816dead447
-	github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.1
+	github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.2
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/hermeznetwork/tracerr v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,10 @@ github.com/0xPolygon/cdk-rpc v0.0.0-20240905074455-431d3c271fe8 h1:Jri+ydl8Puddd
 github.com/0xPolygon/cdk-rpc v0.0.0-20240905074455-431d3c271fe8/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
 github.com/0xPolygonHermez/zkevm-data-streamer v0.2.6 h1:BSO1uu6dmLQ5kKb3uyDvsUxbnIoyumKvlwr0OtpTYMo=
 github.com/0xPolygonHermez/zkevm-data-streamer v0.2.6/go.mod h1:RC6ouyNsUtJrv5aGPcM6Dm5xhXN209tRSzcsJsaOtZI=
-github.com/0xPolygonHermez/zkevm-ethtx-manager v0.1.10-0.20240716105056-c051c96d0234 h1:QElCysO7f2xaknY/RDjxcs7IVmcgORfsCX2g+YD0Ko4=
-github.com/0xPolygonHermez/zkevm-ethtx-manager v0.1.10-0.20240716105056-c051c96d0234/go.mod h1:zBZWxwOHKlw+ghd9roQLgIkDZWA7e7qO3EsfQQT/+oQ=
 github.com/0xPolygonHermez/zkevm-ethtx-manager v0.1.10-0.20240930120324-65816dead447 h1:8nZjZrHZo+P9hTkhwtQ4J6eh9v4MTMtVb9jRDra8h0s=
 github.com/0xPolygonHermez/zkevm-ethtx-manager v0.1.10-0.20240930120324-65816dead447/go.mod h1:4iWpcwMOZJPapUzFB/HjTAM0X/gltHSEzQHE0lOt+eY=
-github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.1 h1:8GbJBNsYO4zrqiBX++et8eQrJDEWEZuo3Ch3M416YnI=
-github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.1/go.mod h1:96i+QSANfbikwlUY3U9MLNtg3656W3dWfbGqH+Od1/k=
+github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.2 h1:DYioOpHDcn7rtojInDTEv7vmnhs8HP6zOSSXSGENM7s=
+github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.2/go.mod h1:96i+QSANfbikwlUY3U9MLNtg3656W3dWfbGqH+Od1/k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=


### PR DESCRIPTION
## Description
-  update zkevm-synchronizer-l1 from [v1.0.1](https://github.com/0xPolygonHermez/zkevm-synchronizer-l1/releases/tag/v1.0.1) to [v1.0.2](https://github.com/0xPolygonHermez/zkevm-synchronizer-l1/releases/tag/v1.0.2): 
       - fix: [#119](https://github.com/0xPolygonHermez/zkevm-synchronizer-l1/issues/119), fails if there are multiple sequencedBatch in same bock because a SQL have wrong order by  (#120)
       - feat: add check to DB configuration (#118)
       - fix: downgrade migrations sql lite, remove scheme prefix from tables names (#117)


