### PR TITLE
feat: add versions command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "anyhow",
  "cdk-config",
  "clap",
+ "colored",
  "dotenvy",
  "execute",
  "reqwest 0.12.8",
@@ -850,6 +851,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "combine"

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -14,6 +14,7 @@ toml = "0.8.14"
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 url = { workspace = true, features = ["serde"] }
+colored = "2.0"
 
 
 cdk-config = { path = "../cdk-config" }

--- a/crates/cdk/src/cli.rs
+++ b/crates/cdk/src/cli.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand, ValueHint};
 
 /// Command line interface.
 #[derive(Parser)]
+#[command(author, version, about, long_about = None)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) cmd: Commands,

--- a/crates/cdk/src/cli.rs
+++ b/crates/cdk/src/cli.rs
@@ -6,24 +6,6 @@ use clap::{Parser, Subcommand, ValueHint};
 /// Command line interface.
 #[derive(Parser)]
 pub(crate) struct Cli {
-    /// The path to the configuration file.
-    #[arg(
-        long,
-        short,
-        value_hint = ValueHint::FilePath,
-        env = "CDK_CONFIG_PATH"
-    )]
-    pub(crate) config: PathBuf,
-
-    /// The path to a chain specification file.
-    #[arg(
-        long,
-        short = 'g',
-        value_hint = ValueHint::FilePath,
-        env = "CDK_GENESIS_PATH"
-    )]
-    pub(crate) chain: PathBuf,
-
     #[command(subcommand)]
     pub(crate) cmd: Commands,
 }
@@ -31,6 +13,15 @@ pub(crate) struct Cli {
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     Node {
+        /// The path to the configuration file.
+        #[arg(
+            long,
+            short,
+            value_hint = ValueHint::FilePath,
+            env = "CDK_CONFIG_PATH"
+        )]
+        config: PathBuf,
+
         /// Components to run.
         #[arg(
             long,
@@ -40,5 +31,24 @@ pub(crate) enum Commands {
         )]
         components: Option<String>,
     },
-    Erigon,
+    Erigon {
+        /// The path to the configuration file.
+        #[arg(
+            long,
+            short,
+            value_hint = ValueHint::FilePath,
+            env = "CDK_CONFIG_PATH"
+        )]
+        config: PathBuf,
+
+        /// The path to a chain specification file.
+        #[arg(
+            long,
+            short = 'g',
+            value_hint = ValueHint::FilePath,
+            env = "CDK_GENESIS_PATH"
+        )]
+        chain: PathBuf,
+    },
+    Versions,
 }

--- a/crates/cdk/src/helpers.rs
+++ b/crates/cdk/src/helpers.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+const CDK_CLIENT_BIN: &str = "cdk-node";
+
+pub(crate) fn get_bin_path() -> String {
+    // This is to find the binary when running in development mode
+    // otherwise it will use system path
+    let mut bin_path = env::var("CARGO_MANIFEST_DIR").unwrap_or(CDK_CLIENT_BIN.into());
+    if bin_path != CDK_CLIENT_BIN {
+        bin_path = format!("{}/../../target/{}", bin_path, CDK_CLIENT_BIN);
+    }
+    bin_path
+}

--- a/crates/cdk/src/main.rs
+++ b/crates/cdk/src/main.rs
@@ -14,6 +14,7 @@ pub mod allocs_render;
 mod cli;
 mod config_render;
 mod logging;
+mod versions;
 
 const CDK_CLIENT_BIN: &str = "cdk-node";
 const CDK_ERIGON_BIN: &str = "cdk-erigon";
@@ -23,12 +24,6 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
-
-    // Read the config
-    let config = read_config(cli.config.clone())?;
-
-    // Initialize the logger
-    logging::tracing(&config.log);
 
     println!(
         r#"🐼
@@ -44,9 +39,9 @@ async fn main() -> anyhow::Result<()> {
     );
 
     match cli.cmd {
-        cli::Commands::Node { components } => node(cli.config, components)?,
-        cli::Commands::Erigon {} => erigon(config, cli.chain).await?,
-        // _ => forward()?,
+        cli::Commands::Node { config, components } => node(config, components)?,
+        cli::Commands::Erigon { config, chain } => erigon(config, chain).await?,
+        cli::Commands::Versions {} => versions::versions(),
     }
 
     Ok(())
@@ -70,7 +65,13 @@ fn read_config(config_path: PathBuf) -> anyhow::Result<Config> {
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.
 pub fn node(config_path: PathBuf, components: Option<String>) -> anyhow::Result<()> {
-    // This is to find the erigon binary when running in development mode
+    // Read the config
+    let config = read_config(config_path.clone())?;
+
+    // Initialize the logger
+    logging::tracing(&config.log);
+
+    // This is to find the binary when running in development mode
     // otherwise it will use system path
     let mut bin_path = env::var("CARGO_MANIFEST_DIR").unwrap_or(CDK_CLIENT_BIN.into());
     if bin_path != CDK_CLIENT_BIN {
@@ -118,7 +119,13 @@ pub fn node(config_path: PathBuf, components: Option<String>) -> anyhow::Result<
 
 /// This is the main erigon entrypoint.
 /// This function starts everything needed to run an Erigon node.
-pub async fn erigon(config: Config, genesis_file: PathBuf) -> anyhow::Result<()> {
+pub async fn erigon(config_path: PathBuf, genesis_file: PathBuf) -> anyhow::Result<()> {
+    // Read the config
+    let config = read_config(config_path.clone())?;
+
+    // Initialize the logger
+    logging::tracing(&config.log);
+
     // Render configuration files
     let chain_id = config.aggregator.chain_id.clone();
     let rpc_url = Url::parse(&config.sequence_sender.rpc_url).unwrap();

--- a/crates/cdk/src/main.rs
+++ b/crates/cdk/src/main.rs
@@ -4,8 +4,8 @@ use alloy_rpc_client::ReqwestClient;
 use cdk_config::Config;
 use clap::Parser;
 use cli::Cli;
+use colored::*;
 use execute::Execute;
-use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 use url::Url;
@@ -13,10 +13,10 @@ use url::Url;
 pub mod allocs_render;
 mod cli;
 mod config_render;
+mod helpers;
 mod logging;
 mod versions;
 
-const CDK_CLIENT_BIN: &str = "cdk-node";
 const CDK_ERIGON_BIN: &str = "cdk-erigon";
 
 #[tokio::main]
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     println!(
+        "{}",
         r#"🐼
   _____      _                            _____ _____  _  __
  |  __ \    | |                          / ____|  __ \| |/ /
@@ -36,6 +37,7 @@ async fn main() -> anyhow::Result<()> {
                 __/ | __/ |                                 
                |___/ |___/                                  
 "#
+        .purple()
     );
 
     match cli.cmd {
@@ -73,10 +75,7 @@ pub fn node(config_path: PathBuf, components: Option<String>) -> anyhow::Result<
 
     // This is to find the binary when running in development mode
     // otherwise it will use system path
-    let mut bin_path = env::var("CARGO_MANIFEST_DIR").unwrap_or(CDK_CLIENT_BIN.into());
-    if bin_path != CDK_CLIENT_BIN {
-        bin_path = format!("{}/../../target/{}", bin_path, CDK_CLIENT_BIN);
-    }
+    let bin_path = helpers::get_bin_path();
 
     let components_param = match components {
         Some(components) => format!("-components={}", components),

--- a/crates/cdk/src/versions.rs
+++ b/crates/cdk/src/versions.rs
@@ -1,32 +1,47 @@
-/// Command to print corresponding versions to the stdout.
+use colored::*;
+use execute::Execute;
+use std::io;
+use std::process::{Command, Output};
+
+fn version() -> Result<Output, io::Error> {
+    let bin_path = crate::helpers::get_bin_path();
+
+    // Run the node passing the config file path as argument
+    let mut command = Command::new(bin_path.clone());
+    command.args(&["version"]);
+
+    command.execute_output()
+}
+
 pub(crate) fn versions() {
-    // Multi-line string to print the versions.
-    println!(
-        r#"
-# FORK 12 IMAGES
-# yq .args .github/tests/forks/fork12.yml
-zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
-zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
-cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
+    // Get the version of the cdk-node binary.
+    let output = version().unwrap();
+    let version = String::from_utf8(output.stdout).unwrap();
 
-# FORK 11 IMAGES
-# yq .args .github/tests/forks/fork11.yml
-# zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
-# zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
-# cdk_erigon_node_image: hermeznetwork/cdk-erigon:acceptance-2.0.0-beta26-0f01107
+    println!("{}", format!("{}", version.trim()).green());
 
-zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
-cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
+    let versions = vec![
+        (
+            "zkEVM Contracts",
+            "https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v8.0.0-rc.4-fork.12",
+        ),
+        ("zkEVM Prover", "v8.0.0-RC12"),
+        ("CDK Erigon", "hermeznetwork/cdk-erigon:0948e33"),
+        (
+            "zkEVM Pool Manager",
+            "hermeznetwork/zkevm-pool-manager:v0.1.1",
+        ),
+        (
+            "CDK Data Availability Node",
+            "0xpolygon/cdk-data-availability:0.0.10",
+        ),
+    ];
 
-cdk_node_image: ghcr.io/0xpolygon/cdk:0.3.0-beta3
-zkevm_da_image: 0xpolygon/cdk-data-availability:0.0.10
-# agglayer_image: nulyjkdhthz/agglayer-rs:pr-318
-agglayer_image: ghcr.io/agglayer/agglayer-rs:pr-96
-zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
-zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
-zkevm_bridge_proxy_image: haproxy:3.0-bookworm
-zkevm_sequence_sender_image: hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12
-zkevm_pool_manager_image: hermeznetwork/zkevm-pool-manager:v0.1.1
-"#
-    )
+    // Multi-line string to print the versions with colors.
+    let formatted_versions: Vec<String> = versions
+        .iter()
+        .map(|(key, value)| format!("{}: {}", key.green(), value.blue()))
+        .collect();
+
+    println!("{}", formatted_versions.join("\n"));
 }

--- a/crates/cdk/src/versions.rs
+++ b/crates/cdk/src/versions.rs
@@ -1,0 +1,32 @@
+/// Command to print corresponding versions to the stdout.
+pub(crate) fn versions() {
+    // Multi-line string to print the versions.
+    println!(
+        r#"
+# FORK 12 IMAGES
+# yq .args .github/tests/forks/fork12.yml
+zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
+zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
+cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
+
+# FORK 11 IMAGES
+# yq .args .github/tests/forks/fork11.yml
+# zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
+# zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
+# cdk_erigon_node_image: hermeznetwork/cdk-erigon:acceptance-2.0.0-beta26-0f01107
+
+zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
+cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
+
+cdk_node_image: ghcr.io/0xpolygon/cdk:0.3.0-beta3
+zkevm_da_image: 0xpolygon/cdk-data-availability:0.0.10
+# agglayer_image: nulyjkdhthz/agglayer-rs:pr-318
+agglayer_image: ghcr.io/agglayer/agglayer-rs:pr-96
+zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
+zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
+zkevm_bridge_proxy_image: haproxy:3.0-bookworm
+zkevm_sequence_sender_image: hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12
+zkevm_pool_manager_image: hermeznetwork/zkevm-pool-manager:v0.1.1
+"#
+    )
+}


### PR DESCRIPTION
This PR splits the previously global required config and genesis flags to different subcommands as not all commands need the same params.

`node` command is getting the node config file
`erigon` command is getting the config file and the genesis file
`versions` command doesn't need any param

Introducing here the `versions` command, simply outputs the corresponding versions of other components. This is a temporary launch requirement until we iterate on more comprehensive status checks.
