### PR TITLE
feat: Add `metadata` field on the certificate

### DIFF
--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -493,6 +493,7 @@ func TestBuildCertificate(t *testing.T) {
 		bridges                 []bridgesync.Bridge
 		claims                  []bridgesync.Claim
 		lastSentCertificateInfo aggsendertypes.CertificateInfo
+		toBlock                 uint64
 		mockFn                  func()
 		expectedCert            *agglayer.Certificate
 		expectedError           bool
@@ -532,10 +533,12 @@ func TestBuildCertificate(t *testing.T) {
 				NewLocalExitRoot: common.HexToHash("0x123"),
 				Height:           1,
 			},
+			toBlock: 10,
 			expectedCert: &agglayer.Certificate{
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
+				Metadata:          createCertificateMetadata(10),
 				BridgeExits: []*agglayer.BridgeExit{
 					{
 						LeafType: agglayer.LeafTypeAsset,
@@ -686,7 +689,7 @@ func TestBuildCertificate(t *testing.T) {
 				l1infoTreeSyncer: mockL1InfoTreeSyncer,
 				log:              log.WithFields("test", "unittest"),
 			}
-			cert, err := aggSender.buildCertificate(context.Background(), tt.bridges, tt.claims, tt.lastSentCertificateInfo)
+			cert, err := aggSender.buildCertificate(context.Background(), tt.bridges, tt.claims, tt.lastSentCertificateInfo, tt.toBlock)
 
 			if tt.expectedError {
 				require.Error(t, err)

--- a/common/common.go
+++ b/common/common.go
@@ -109,3 +109,19 @@ func NewKeyFromKeystore(cfg types.KeystoreFileConfig) (*ecdsa.PrivateKey, error)
 	}
 	return key.PrivateKey, nil
 }
+
+// AsLittleEndianSlice converts a big.Int to a 32-byte little-endian representation.
+func AsLittleEndianSlice(n *big.Int) []byte {
+	// Get the absolute value in big-endian byte slice
+	beBytes := n.Bytes()
+
+	// Initialize a 32-byte array for the result
+	leBytes := make([]byte, 32)
+
+	// Fill the array in reverse order to convert to little-endian
+	for i := 0; i < len(beBytes) && i < 32; i++ {
+		leBytes[i] = beBytes[len(beBytes)-1-i]
+	}
+
+	return leBytes
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestAsLittleEndianSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    *big.Int
+		expected []byte
+	}{
+		{
+			name:     "Zero value",
+			input:    big.NewInt(0),
+			expected: make([]byte, 32),
+		},
+		{
+			name:     "Positive value",
+			input:    big.NewInt(123456789),
+			expected: append([]byte{21, 205, 91, 7}, make([]byte, 28)...),
+		},
+		{
+			name:     "Negative value",
+			input:    big.NewInt(-123456789),
+			expected: append([]byte{21, 205, 91, 7}, make([]byte, 28)...),
+		},
+		{
+			name: "Large positive value",
+			input: new(big.Int).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			expected: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := AsLittleEndianSlice(tt.input)
+			if len(result) != 32 {
+				t.Errorf("expected length 32, got %d", len(result))
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("expected byte at index %d to be %x, got %x", i, tt.expected[i], result[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

### Metadata field

This PR adds a `Metadata` field to certificate. This field is a `Hash` field, that different chains can use to store arbitrary data relevant to them. In our case, we store the the number of block on L2 until which we built the given certificate.

For example, we built a certificate for blocks 10 to 20 on L2. We will store number 20 in a form of hash to the `Metadata` field on the certificate.

Once the `agglayer` team introduces the rpc endpoint to get the last sent certificate by our network, we can use that field to know from which block to build the next certificate. For now, we use a local database on the `aggsender` for this, but we want to avoid cases where we might lose our local db, or it gets corrupted, or we missed a lot of blocks.

### Invalid signer issue

This PR also fixes the issue of signing a wrong certificate hash, which caused the `InvalidSigner` problem on the `agglayer`.
`agglayer` signs the same data as in `HashToSign` function.

Global index on imported bridge exits is first converted to little endian slice, and then hashed, as per `agglayer` code.