### PR TITLE
fix: revert changes on calculation of merkel proof

### DIFF
--- a/l1infotree/tree.go
+++ b/l1infotree/tree.go
@@ -109,17 +109,15 @@ func (mt *L1InfoTree) ComputeMerkleProof(gerIndex uint32, leaves [][32]byte) ([]
 		if len(leaves)%2 == 1 {
 			leaves = append(leaves, mt.zeroHashes[h])
 		}
-		if index%2 == 1 { // If it is odd
-			siblings = append(siblings, leaves[index-1])
-		} else if len(leaves) > 1 { // It is even
-			if index >= uint32(len(leaves)) {
-				// siblings = append(siblings, mt.zeroHashes[h])
+		if index >= uint32(len(leaves)) {
+			siblings = append(siblings, mt.zeroHashes[h])
+		} else {
+			if index%2 == 1 { // If it is odd
 				siblings = append(siblings, leaves[index-1])
-			} else {
+			} else { // It is even
 				siblings = append(siblings, leaves[index+1])
 			}
 		}
-
 		var (
 			nsi    [][][]byte
 			hashes [][32]byte

--- a/l1infotree/tree_test.go
+++ b/l1infotree/tree_test.go
@@ -3,7 +3,6 @@ package l1infotree_test
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 
@@ -129,57 +128,4 @@ func TestAddLeaf2(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testVector.NewRoot, newRoot)
 	}
-}
-
-func TestAddLeaf2TestLastLeaf(t *testing.T) {
-	mt, err := l1infotree.NewL1InfoTree(log.GetDefaultLogger(), uint8(32), [][32]byte{})
-	require.NoError(t, err)
-	leaves := [][32]byte{
-		common.HexToHash("0x6a617315ffc0a6831d2de6331f8d3e053889e9385696c13f11853fdcba50e123"),
-		common.HexToHash("0x1cff355b898cf285bcc3f84a8d6ed51c19fe87ab654f4146f2dc7723a59fc741"),
-	}
-	siblings, root, err := mt.ComputeMerkleProof(2, leaves)
-	require.NoError(t, err)
-	fmt.Printf("Root: %s\n", root.String())
-	for i := 0; i < len(siblings); i++ {
-		hash := common.BytesToHash(siblings[i][:])
-		fmt.Printf("Sibling %d: %s\n", i, hash.String())
-	}
-	expectedProof := []string{
-		"0x1cff355b898cf285bcc3f84a8d6ed51c19fe87ab654f4146f2dc7723a59fc741",
-		"0x7ae3eca221dee534b82adffb8003ad3826ddf116132e4ff55c681ff723bc7e42",
-		"0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30",
-		"0x21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85",
-		"0xe58769b32a1beaf1ea27375a44095a0d1fb664ce2dd358e7fcbfb78c26a19344",
-		"0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
-		"0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968",
-		"0xffd70157e48063fc33c97a050f7f640233bf646cc98d9524c6b92bcf3ab56f83",
-		"0x9867cc5f7f196b93bae1e27e6320742445d290f2263827498b54fec539f756af",
-		"0xcefad4e508c098b9a7e1d8feb19955fb02ba9675585078710969d3440f5054e0",
-		"0xf9dc3e7fe016e050eff260334f18a5d4fe391d82092319f5964f2e2eb7c1c3a5",
-		"0xf8b13a49e282f609c317a833fb8d976d11517c571d1221a265d25af778ecf892",
-		"0x3490c6ceeb450aecdc82e28293031d10c7d73bf85e57bf041a97360aa2c5d99c",
-		"0xc1df82d9c4b87413eae2ef048f94b4d3554cea73d92b0f7af96e0271c691e2bb",
-		"0x5c67add7c6caf302256adedf7ab114da0acfe870d449a3a489f781d659e8becc",
-		"0xda7bce9f4e8618b6bd2f4132ce798cdc7a60e7e1460a7299e3c6342a579626d2",
-		"0x2733e50f526ec2fa19a22b31e8ed50f23cd1fdf94c9154ed3a7609a2f1ff981f",
-		"0xe1d3b5c807b281e4683cc6d6315cf95b9ade8641defcb32372f1c126e398ef7a",
-		"0x5a2dce0a8a7f68bb74560f8f71837c2c2ebbcbf7fffb42ae1896f13f7c7479a0",
-		"0xb46a28b6f55540f89444f63de0378e3d121be09e06cc9ded1c20e65876d36aa0",
-		"0xc65e9645644786b620e2dd2ad648ddfcbf4a7e5b1a3a4ecfe7f64667a3f0b7e2",
-		"0xf4418588ed35a2458cffeb39b93d26f18d2ab13bdce6aee58e7b99359ec2dfd9",
-		"0x5a9c16dc00d6ef18b7933a6f8dc65ccb55667138776f7dea101070dc8796e377",
-		"0x4df84f40ae0c8229d0d6069e5c8f39a7c299677a09d367fc7b05e3bc380ee652",
-		"0xcdc72595f74c7b1043d0e1ffbab734648c838dfb0527d971b602bc216c9619ef",
-		"0x0abf5ac974a1ed57f4050aa510dd9c74f508277b39d7973bb2dfccc5eeb0618d",
-		"0xb8cd74046ff337f0a7bf2c8e03e10f642c1886798d71806ab1e888d9e5ee87d0",
-		"0x838c5655cb21c6cb83313b5a631175dff4963772cce9108188b34ac87c81c41e",
-		"0x662ee4dd2dd7b2bc707961b1e646c4047669dcb6584f0d8d770daf5d7e7deb2e",
-		"0x388ab20e2573d171a88108e79d820e98f26c0b84aa8b2f4aa4968dbb818ea322",
-		"0x93237c50ba75ee485f4c22adf2f741400bdf8d6a9cc7df7ecae576221665d735",
-		"0x8448818bb4ae4562849e949e17ac16e0be16688e156b5cf15e098c627c0056a9"}
-	for i := 0; i < len(siblings); i++ {
-		require.Equal(t, expectedProof[i], "0x"+hex.EncodeToString(siblings[i][:]))
-	}
-	require.Equal(t, "0xb85687d05a6bdccadcc1170a0e2bbba6855c35c984a0bc91697bc066bd38a338", root.String())
 }


### PR DESCRIPTION
## Description

Revert changes on l1infotree/tree.go calculating merkel proof. This object is used by aggregator

