### PR TITLE
feat: add timestamps to certificate

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -184,14 +184,14 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 
 	createdTime := time.Now().UTC().UnixMilli()
 	certInfo := aggsendertypes.CertificateInfo{
-		Height:           certificate.Height,
-		CertificateID:    certificateHash,
-		NewLocalExitRoot: certificate.NewLocalExitRoot,
-		FromBlock:        fromBlock,
-		ToBlock:          toBlock,
-		CreatedAt:        createdTime,
-		UpdatedAt:        createdTime,
-		Raw:              string(raw),
+		Height:            certificate.Height,
+		CertificateID:     certificateHash,
+		NewLocalExitRoot:  certificate.NewLocalExitRoot,
+		FromBlock:         fromBlock,
+		ToBlock:           toBlock,
+		CreatedAt:         createdTime,
+		UpdatedAt:         createdTime,
+		SignedCertificate: string(raw),
 	}
 
 	if err := a.storage.SaveLastSentCertificate(ctx, certInfo); err != nil {

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -177,12 +177,15 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 
 	a.log.Debugf("certificate send: Height: %d hash: %s", signedCertificate.Height, certificateHash.String())
 
+	createdTime := time.Now().UTC().UnixMilli()
 	certInfo := aggsendertypes.CertificateInfo{
 		Height:           certificate.Height,
 		CertificateID:    certificateHash,
 		NewLocalExitRoot: certificate.NewLocalExitRoot,
 		FromBlock:        fromBlock,
 		ToBlock:          toBlock,
+		CreatedAt:        createdTime,
+		UpdatedAt:        createdTime,
 	}
 
 	if err := a.storage.SaveLastSentCertificate(ctx, certInfo); err != nil {
@@ -504,6 +507,7 @@ func (a *AggSender) checkPendingCertificatesStatus(ctx context.Context) {
 				certificateHeader.String(), certificate.Status, certificateHeader.Status)
 
 			certificate.Status = certificateHeader.Status
+			certificate.UpdatedAt = time.Now().UTC().UnixMilli()
 
 			if err := a.storage.UpdateCertificateStatus(ctx, *certificate); err != nil {
 				a.log.Errorf("error updating certificate %s status in storage: %w", certificateHeader.String(), err)

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -177,6 +177,11 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 
 	a.log.Debugf("certificate send: Height: %d hash: %s", signedCertificate.Height, certificateHash.String())
 
+	raw, err := json.Marshal(signedCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling signed certificate: %w", err)
+	}
+
 	createdTime := time.Now().UTC().UnixMilli()
 	certInfo := aggsendertypes.CertificateInfo{
 		Height:           certificate.Height,
@@ -186,6 +191,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 		ToBlock:          toBlock,
 		CreatedAt:        createdTime,
 		UpdatedAt:        createdTime,
+		Raw:              string(raw),
 	}
 
 	if err := a.storage.SaveLastSentCertificate(ctx, certInfo); err != nil {

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/cdk/agglayer"
 	"github.com/0xPolygon/cdk/aggsender/db/migrations"
@@ -24,6 +25,8 @@ func Test_Storage(t *testing.T) {
 	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), path)
 	require.NoError(t, err)
 
+	updateTime := time.Now().UTC().UnixMilli()
+
 	t.Run("SaveLastSentCertificate", func(t *testing.T) {
 		certificate := types.CertificateInfo{
 			Height:           1,
@@ -32,6 +35,8 @@ func Test_Storage(t *testing.T) {
 			FromBlock:        1,
 			ToBlock:          2,
 			Status:           agglayer.Settled,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -50,6 +55,8 @@ func Test_Storage(t *testing.T) {
 			FromBlock:        3,
 			ToBlock:          4,
 			Status:           agglayer.Settled,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -75,6 +82,8 @@ func Test_Storage(t *testing.T) {
 			FromBlock:        5,
 			ToBlock:          6,
 			Status:           agglayer.Pending,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -104,6 +113,8 @@ func Test_Storage(t *testing.T) {
 			FromBlock:        17,
 			ToBlock:          18,
 			Status:           agglayer.Pending,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -124,6 +135,8 @@ func Test_Storage(t *testing.T) {
 				FromBlock:        7,
 				ToBlock:          8,
 				Status:           agglayer.Settled,
+				CreatedAt:        updateTime,
+				UpdatedAt:        updateTime,
 			},
 			{
 				Height:           9,
@@ -132,6 +145,8 @@ func Test_Storage(t *testing.T) {
 				FromBlock:        9,
 				ToBlock:          10,
 				Status:           agglayer.Pending,
+				CreatedAt:        updateTime,
+				UpdatedAt:        updateTime,
 			},
 			{
 				Height:           11,
@@ -140,6 +155,8 @@ func Test_Storage(t *testing.T) {
 				FromBlock:        11,
 				ToBlock:          12,
 				Status:           agglayer.InError,
+				CreatedAt:        updateTime,
+				UpdatedAt:        updateTime,
 			},
 		}
 
@@ -187,6 +204,8 @@ func Test_Storage(t *testing.T) {
 			FromBlock:        13,
 			ToBlock:          14,
 			Status:           agglayer.Pending,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -213,6 +232,8 @@ func Test_SaveLastSentCertificate(t *testing.T) {
 	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), path)
 	require.NoError(t, err)
 
+	updateTime := time.Now().UTC().UnixMilli()
+
 	t.Run("SaveNewCertificate", func(t *testing.T) {
 		certificate := types.CertificateInfo{
 			Height:           1,
@@ -221,6 +242,8 @@ func Test_SaveLastSentCertificate(t *testing.T) {
 			FromBlock:        1,
 			ToBlock:          2,
 			Status:           agglayer.Settled,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -238,6 +261,8 @@ func Test_SaveLastSentCertificate(t *testing.T) {
 			FromBlock:        3,
 			ToBlock:          4,
 			Status:           agglayer.InError,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
@@ -267,6 +292,8 @@ func Test_SaveLastSentCertificate(t *testing.T) {
 			FromBlock:        7,
 			ToBlock:          8,
 			Status:           agglayer.Settled,
+			CreatedAt:        updateTime,
+			UpdatedAt:        updateTime,
 		}
 
 		// Close the database to force an error

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -348,22 +348,22 @@ func Test_SaveLastSentCertificate(t *testing.T) {
 		require.NoError(t, err)
 
 		certificate := types.CertificateInfo{
-			Height:           1,
-			CertificateID:    common.HexToHash("0x9"),
-			NewLocalExitRoot: common.HexToHash("0x2"),
-			FromBlock:        1,
-			ToBlock:          10,
-			Status:           agglayer.Pending,
-			CreatedAt:        updateTime,
-			UpdatedAt:        updateTime,
-			Raw:              string(raw),
+			Height:            1,
+			CertificateID:     common.HexToHash("0x9"),
+			NewLocalExitRoot:  common.HexToHash("0x2"),
+			FromBlock:         1,
+			ToBlock:           10,
+			Status:            agglayer.Pending,
+			CreatedAt:         updateTime,
+			UpdatedAt:         updateTime,
+			SignedCertificate: string(raw),
 		}
 		require.NoError(t, storage.SaveLastSentCertificate(ctx, certificate))
 
 		certificateFromDB, err := storage.GetCertificateByHeight(certificate.Height)
 		require.NoError(t, err)
 		require.Equal(t, certificate, certificateFromDB)
-		require.Equal(t, raw, []byte(certificateFromDB.Raw))
+		require.Equal(t, raw, []byte(certificateFromDB.SignedCertificate))
 
 		require.NoError(t, storage.clean())
 	})

--- a/aggsender/db/migrations/0001.sql
+++ b/aggsender/db/migrations/0001.sql
@@ -10,6 +10,6 @@ CREATE TABLE certificate_info (
     from_block                  INTEGER NOT NULL,
     to_block                    INTEGER NOT NULL,
     created_at                  INTEGER NOT NULL,
-	updated_at                  INTEGER NOT NULL,
+    updated_at                  INTEGER NOT NULL,
     signed_certificate          TEXT
 );

--- a/aggsender/db/migrations/0001.sql
+++ b/aggsender/db/migrations/0001.sql
@@ -10,5 +10,6 @@ CREATE TABLE certificate_info (
     from_block                  INTEGER NOT NULL,
     to_block                    INTEGER NOT NULL,
     created_at                  INTEGER NOT NULL,
-	updated_at                  INTEGER NOT NULL
+	updated_at                  INTEGER NOT NULL,
+    raw                         TEXT
 );

--- a/aggsender/db/migrations/0001.sql
+++ b/aggsender/db/migrations/0001.sql
@@ -11,5 +11,5 @@ CREATE TABLE certificate_info (
     to_block                    INTEGER NOT NULL,
     created_at                  INTEGER NOT NULL,
 	updated_at                  INTEGER NOT NULL,
-    raw                         TEXT
+    signed_certificate          TEXT
 );

--- a/aggsender/db/migrations/0001.sql
+++ b/aggsender/db/migrations/0001.sql
@@ -8,5 +8,7 @@ CREATE TABLE certificate_info (
     status                      INTEGER NOT NULL,
     new_local_exit_root         VARCHAR NOT NULL,
     from_block                  INTEGER NOT NULL,
-    to_block                    INTEGER NOT NULL
+    to_block                    INTEGER NOT NULL,
+    created_at                  INTEGER NOT NULL,
+	updated_at                  INTEGER NOT NULL
 );

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -52,15 +52,15 @@ type Logger interface {
 }
 
 type CertificateInfo struct {
-	Height           uint64                     `meddler:"height"`
-	CertificateID    common.Hash                `meddler:"certificate_id,hash"`
-	NewLocalExitRoot common.Hash                `meddler:"new_local_exit_root,hash"`
-	FromBlock        uint64                     `meddler:"from_block"`
-	ToBlock          uint64                     `meddler:"to_block"`
-	Status           agglayer.CertificateStatus `meddler:"status"`
-	CreatedAt        int64                      `meddler:"created_at"`
-	UpdatedAt        int64                      `meddler:"updated_at"`
-	Raw              string                     `meddler:"raw"`
+	Height            uint64                     `meddler:"height"`
+	CertificateID     common.Hash                `meddler:"certificate_id,hash"`
+	NewLocalExitRoot  common.Hash                `meddler:"new_local_exit_root,hash"`
+	FromBlock         uint64                     `meddler:"from_block"`
+	ToBlock           uint64                     `meddler:"to_block"`
+	Status            agglayer.CertificateStatus `meddler:"status"`
+	CreatedAt         int64                      `meddler:"created_at"`
+	UpdatedAt         int64                      `meddler:"updated_at"`
+	SignedCertificate string                     `meddler:"signed_certificate"`
 }
 
 func (c CertificateInfo) String() string {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -60,6 +60,7 @@ type CertificateInfo struct {
 	Status           agglayer.CertificateStatus `meddler:"status"`
 	CreatedAt        int64                      `meddler:"created_at"`
 	UpdatedAt        int64                      `meddler:"updated_at"`
+	Raw              string                     `meddler:"raw"`
 }
 
 func (c CertificateInfo) String() string {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/cdk/agglayer"
 	"github.com/0xPolygon/cdk/bridgesync"
@@ -57,9 +58,27 @@ type CertificateInfo struct {
 	FromBlock        uint64                     `meddler:"from_block"`
 	ToBlock          uint64                     `meddler:"to_block"`
 	Status           agglayer.CertificateStatus `meddler:"status"`
+	CreatedAt        int64                      `meddler:"created_at"`
+	UpdatedAt        int64                      `meddler:"updated_at"`
 }
 
 func (c CertificateInfo) String() string {
-	return fmt.Sprintf("Height: %d, CertificateID: %s, FromBlock: %d, ToBlock: %d, NewLocalExitRoot: %s",
-		c.Height, c.CertificateID.String(), c.FromBlock, c.ToBlock, c.NewLocalExitRoot.String())
+	return fmt.Sprintf(
+		"Height: %d\n"+
+			"CertificateID: %s\n"+
+			"FromBlock: %d\n"+
+			"ToBlock: %d\n"+
+			"NewLocalExitRoot: %s\n"+
+			"Status: %s\n"+
+			"CreatedAt: %s\n"+
+			"UpdatedAt: %s\n",
+		c.Height,
+		c.CertificateID.String(),
+		c.FromBlock,
+		c.ToBlock,
+		c.NewLocalExitRoot.String(),
+		c.Status.String(),
+		time.UnixMilli(c.CreatedAt),
+		time.UnixMilli(c.UpdatedAt),
+	)
 }


### PR DESCRIPTION
## Description

This PR adds three new fields to the `CertificateInfo` struct we save in `aggsender` `db`:
- `created_at` - a timestamp that indicates when was the certificate created on the `aggsender`.
- `updated_at` - a timestamp that indicates when was the certificate last updated. For example, it moved from Pending to Candidate.
- `signed_cerificated` - raw string of the certificate that we sent to `agglayer`.

All of these fields will be used for easier debugging and logging.
