### PR TITLE
fix:  local configuration bumping kurtosis to 0.2.29

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: "kurtosis-cdk"
-        ref: "v0.2.18"
+        ref: "v0.2.19"
 
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0

--- a/scripts/local_config
+++ b/scripts/local_config
@@ -316,10 +316,10 @@ EOF
 ###############################################################################
 function create_dest_folder(){
     export DEST=${TMP_CDK_FOLDER}/local_config
-    export path_rw_data=${TMP_CDK_FOLDER}/runtime
+    export zkevm_path_rw_data=${TMP_CDK_FOLDER}/runtime
     [ ! -d ${DEST} ] && mkdir -p ${DEST}
     rm $DEST/*
-    mkdir $path_rw_data
+    mkdir $zkevm_path_rw_data
 }
 ###############################################################################
 function download_kurtosis_artifacts(){

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -7,4 +7,4 @@ args:
   zkevm_use_gas_token_contract: true
   data_availability_mode: rollup
   sequencer_type: erigon
-  zkevm_path_rw_data: /tmp/
+  

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -7,3 +7,4 @@ args:
   zkevm_use_gas_token_contract: true
   data_availability_mode: rollup
   sequencer_type: erigon
+  zkevm_path_rw_data: /tmp/

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -6,3 +6,4 @@ args:
   zkevm_use_gas_token_contract: true
   data_availability_mode: cdk-validium
   sequencer_type: erigon
+  zkevm_path_rw_data: /tmp/

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -6,4 +6,5 @@ args:
   zkevm_use_gas_token_contract: true
   data_availability_mode: cdk-validium
   sequencer_type: erigon
-  zkevm_path_rw_data: /tmp/
+  
+

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -1,4 +1,4 @@
-PathRWData = "{{.path_rw_data}}/"
+PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 AggLayerURL="{{.agglayer_url}}"
@@ -67,6 +67,6 @@ Outputs = ["stderr"]
 [AggSender]
 CertificateSendInterval = "1m"
 CheckSettledInterval = "5s"
-SaveCertificatesToFilesPath = "{{.path_rw_data}}/"
+SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}/"
 
 

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -1,4 +1,4 @@
-PathRWData = "/tmp/"
+PathRWData = "{{.path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 AggLayerURL="{{.agglayer_url}}"
@@ -58,3 +58,4 @@ Outputs = ["stderr"]
        
 [AggSender]
 SequencerPrivateKey = {Path = "{{or .zkevm_l2_agglayer_keystore_file "/pk/sequencer.keystore"}}", Password = "{{.zkevm_l2_agglayer_keystore_password}}"}
+SaveCertificatesToFilesPath = "{{.path_rw_data}}/"

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -5,7 +5,12 @@ AggLayerURL="{{.agglayer_url}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}
+
 {{if eq .zkevm_rollup_fork_id "12"}}
+ContractVersions = "banana"
+{{else if eq .zkevm_rollup_fork_id "13"}}
+# Doesn't look like this is needed at the moment, but soon perhaps?
+# ContractVersions = "durian"
 ContractVersions = "banana"
 {{else}}
 ContractVersions = "elderberry"
@@ -46,7 +51,10 @@ Outputs = ["stderr"]
 
 [Aggregator]
         Port = "{{.zkevm_aggregator_port}}"
-
+        RetryTime = "30s"
+        VerifyProofInterval = "10s"
+        GasOffset = 150000
+        SettlementBackend = "agglayer"
         [Aggregator.DB]
                 Name = "{{.aggregator_db.name}}"
                 User = "{{.aggregator_db.user}}"
@@ -57,5 +65,8 @@ Outputs = ["stderr"]
                 MaxConns = 200
        
 [AggSender]
-SequencerPrivateKey = {Path = "{{or .zkevm_l2_agglayer_keystore_file "/pk/sequencer.keystore"}}", Password = "{{.zkevm_l2_agglayer_keystore_password}}"}
+CertificateSendInterval = "1m"
+CheckSettledInterval = "5s"
 SaveCertificatesToFilesPath = "{{.path_rw_data}}/"
+
+


### PR DESCRIPTION
## Description

- It set the config param `PathRWData` to a variable that can be set depending of local run or kurtosis:
    -  Executing `script/local_config` writes all data on `./tmp/cdk/runtime/` 
- Fix the parameters required by kurtosis to run
