### PR TITLE
feat: l1infotreesync can be run as individual component (#188)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -529,7 +529,7 @@ func runL1InfoTreeSyncerIfNeeded(
 	reorgDetector *reorgdetector.ReorgDetector,
 ) *l1infotreesync.L1InfoTreeSync {
 	if !isNeeded([]string{cdkcommon.AGGORACLE, cdkcommon.RPC,
-		cdkcommon.SEQUENCE_SENDER, cdkcommon.AGGSENDER}, components) {
+		cdkcommon.SEQUENCE_SENDER, cdkcommon.AGGSENDER, cdkcommon.L1INFOTREESYNC}, components) {
 		return nil
 	}
 	l1InfoTreeSync, err := l1infotreesync.New(
@@ -560,6 +560,7 @@ func runL1ClientIfNeeded(components []string, urlRPCL1 string) *ethclient.Client
 		cdkcommon.SEQUENCE_SENDER, cdkcommon.AGGREGATOR,
 		cdkcommon.AGGORACLE, cdkcommon.RPC,
 		cdkcommon.AGGSENDER,
+		cdkcommon.L1INFOTREESYNC,
 	}, components) {
 		return nil
 	}
@@ -594,7 +595,8 @@ func runReorgDetectorL1IfNeeded(
 ) (*reorgdetector.ReorgDetector, chan error) {
 	if !isNeeded([]string{
 		cdkcommon.SEQUENCE_SENDER, cdkcommon.AGGREGATOR,
-		cdkcommon.AGGORACLE, cdkcommon.RPC, cdkcommon.AGGSENDER},
+		cdkcommon.AGGORACLE, cdkcommon.RPC, cdkcommon.AGGSENDER,
+		cdkcommon.L1INFOTREESYNC},
 		components) {
 		return nil, nil
 	}

--- a/common/components.go
+++ b/common/components.go
@@ -15,4 +15,6 @@ const (
 	PROVER = "prover"
 	// AGGSENDER name to identify the aggsender component
 	AGGSENDER = "aggsender"
+	// L1INFOTREESYNC name to identify the l1infotreesync component
+	L1INFOTREESYNC = "l1infotreesync"
 )


### PR DESCRIPTION
## Description

Cherry pick ssender sync only on branch 0.4.0 to be using during Cardona update preparation.