### PR TITLE
feat: improve logs

### DIFF
--- a/agglayer/types.go
+++ b/agglayer/types.go
@@ -112,27 +112,14 @@ type Certificate struct {
 	Metadata            common.Hash           `json:"metadata"`
 }
 
-func (c *Certificate) String() string {
-	res := fmt.Sprintf("NetworkID: %d, Height: %d, PrevLocalExitRoot: %s, NewLocalExitRoot: %s,  Metadata: %s\n",
-		c.NetworkID, c.Height, common.Bytes2Hex(c.PrevLocalExitRoot[:]),
-		common.Bytes2Hex(c.NewLocalExitRoot[:]), common.Bytes2Hex(c.Metadata[:]))
-
-	if c.BridgeExits == nil {
-		res += "    BridgeExits: nil\n"
-	} else {
-		for i, bridgeExit := range c.BridgeExits {
-			res += fmt.Sprintf(", BridgeExit[%d]: %s\n", i, bridgeExit.String())
-		}
+// Brief returns a string with a brief cert
+func (c *Certificate) Brief() string {
+	if c == nil {
+		return nilStr
 	}
-
-	if c.ImportedBridgeExits == nil {
-		res += "    ImportedBridgeExits: nil\n"
-	} else {
-		for i, importedBridgeExit := range c.ImportedBridgeExits {
-			res += fmt.Sprintf("    ImportedBridgeExit[%d]: %s\n", i, importedBridgeExit.String())
-		}
-	}
-
+	res := fmt.Sprintf("agglayer.Cert {height: %d prevLER: %s newLER:%s exits:%d imported_exits:%d}", c.Height,
+		common.Bytes2Hex(c.PrevLocalExitRoot[:]), common.Bytes2Hex(c.NewLocalExitRoot[:]),
+		len(c.BridgeExits), len(c.ImportedBridgeExits))
 	return res
 }
 
@@ -181,8 +168,8 @@ type SignedCertificate struct {
 	Signature *Signature `json:"signature"`
 }
 
-func (s *SignedCertificate) String() string {
-	return fmt.Sprintf("Certificate:%s,\nSignature: %s", s.Certificate.String(), s.Signature.String())
+func (s *SignedCertificate) Brief() string {
+	return fmt.Sprintf("Certificate:%s,\nSignature: %s", s.Certificate.Brief(), s.Signature.String())
 }
 
 // CopyWithDefaulting returns a shallow copy of the signed certificate

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -199,7 +199,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 	}
 
 	a.saveCertificateToFile(signedCertificate)
-	a.log.Infof("certificate ready to be send to AggLayer: %s", signedCertificate.String())
+	a.log.Infof("certificate ready to be send to AggLayer: %s", signedCertificate.Brief())
 	certificateHash, err := a.aggLayerClient.SendCertificate(signedCertificate)
 	if err != nil {
 		return nil, fmt.Errorf("error sending certificate: %w", err)
@@ -209,7 +209,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 
 	raw, err := json.Marshal(signedCertificate)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling signed certificate: %w", err)
+		return nil, fmt.Errorf("error marshalling signed certificate. Cert:%s. Err: %w", signedCertificate.Brief(), err)
 	}
 
 	createdTime := time.Now().UTC().UnixMilli()
@@ -228,12 +228,12 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 	// TODO: Improve this case, if a cert is not save in the storage, we are going to settle a unknown certificate
 	err = a.saveCertificateToStorage(ctx, certInfo, a.cfg.MaxRetriesStoreCertificate)
 	if err != nil {
-		a.log.Errorf("error saving certificate to storage: %w", err)
+		a.log.Errorf("error saving certificate  to storage. Cert:%s Err: %w", certInfo.String(), err)
 		return nil, fmt.Errorf("error saving last sent certificate %s in db: %w", certInfo.String(), err)
 	}
 
 	a.log.Infof("certificate: %s sent successfully for range of l2 blocks (from block: %d, to block: %d) cert:%s",
-		certificateHash, fromBlock, toBlock, signedCertificate.String())
+		certificateHash, fromBlock, toBlock, signedCertificate.Brief())
 
 	return signedCertificate, nil
 }

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -77,16 +77,16 @@ func (c *CertificateInfo) String() string {
 	if c.PreviousLocalExitRoot != nil {
 		previousLocalExitRoot = c.PreviousLocalExitRoot.String()
 	}
-	return fmt.Sprintf(
+	return fmt.Sprintf("aggsender.CertificateInfo: "+
 		"Height: %d "+
-			"CertificateID: %s "+
-			"PreviousLocalExitRoot: %s "+
-			"NewLocalExitRoot: %s "+
-			"Status: %s "+
-			"FromBlock: %d "+
-			"ToBlock: %d "+
-			"CreatedAt: %s "+
-			"UpdatedAt: %s",
+		"CertificateID: %s "+
+		"PreviousLocalExitRoot: %s "+
+		"NewLocalExitRoot: %s "+
+		"Status: %s "+
+		"FromBlock: %d "+
+		"ToBlock: %d "+
+		"CreatedAt: %s "+
+		"UpdatedAt: %s",
 		c.Height,
 		c.CertificateID.String(),
 		previousLocalExitRoot,

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk/etherman"
+	"github.com/0xPolygon/cdk/log"
 	"github.com/0xPolygon/cdk/sync"
 	tree "github.com/0xPolygon/cdk/tree/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -111,7 +112,8 @@ func newBridgeSync(
 	originNetwork uint32,
 	syncFullClaims bool,
 ) (*BridgeSync, error) {
-	processor, err := newProcessor(dbPath, l1OrL2ID)
+	logger := log.WithFields("bridge-syncer", l1OrL2ID)
+	processor, err := newProcessor(dbPath, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +158,13 @@ func newBridgeSync(
 	if err != nil {
 		return nil, err
 	}
+	logger.Infof("BridgeSyncer [%s] created: dbPath: %s initialBlock:%d bridgeAddr: %s, syncFullClaims: %d,"+
+		" maxRetryAttemptsAfterError:%d RetryAfterErrorPeriod:%s"+
+		"syncBlockChunkSize: %d, blockFinalityType: %s waitForNewBlocksPeriod: %s",
+		l1OrL2ID,
+		dbPath, initialBlock, bridge.String(), syncFullClaims,
+		maxRetryAttemptsAfterError, retryAfterErrorPeriod.String(),
+		syncBlockChunkSize, blockFinalityType, waitForNewBlocksPeriod.String())
 
 	return &BridgeSync{
 		processor:     processor,

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -109,7 +109,7 @@ type processor struct {
 	bridgeContract BridgeContractor
 }
 
-func newProcessor(dbPath, loggerPrefix string) (*processor, error) {
+func newProcessor(dbPath string, logger *log.Logger) (*processor, error) {
 	err := migrations.RunMigrations(dbPath)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func newProcessor(dbPath, loggerPrefix string) (*processor, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger := log.WithFields("bridge-syncer", loggerPrefix)
+
 	exitTree := tree.NewAppendOnlyTree(db, "")
 	return &processor{
 		db:       db,

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -82,7 +82,8 @@ func TestProceessor(t *testing.T) {
 	log.Debugf("sqlite path: %s", path)
 	err := migrationsBridge.RunMigrations(path)
 	require.NoError(t, err)
-	p, err := newProcessor(path, "foo")
+	logger := log.WithFields("bridge-syncer", "foo")
+	p, err := newProcessor(path, logger)
 	require.NoError(t, err)
 	actions := []processAction{
 		// processed: ~
@@ -735,7 +736,8 @@ func TestInsertAndGetClaim(t *testing.T) {
 	log.Debugf("sqlite path: %s", path)
 	err := migrationsBridge.RunMigrations(path)
 	require.NoError(t, err)
-	p, err := newProcessor(path, "foo")
+	logger := log.WithFields("bridge-syncer", "foo")
+	p, err := newProcessor(path, logger)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -828,7 +830,8 @@ func TestGetBridgesPublished(t *testing.T) {
 
 			path := path.Join(t.TempDir(), "file::memory:?cache=shared")
 			require.NoError(t, migrationsBridge.RunMigrations(path))
-			p, err := newProcessor(path, "foo")
+			logger := log.WithFields("bridge-syncer", "foo")
+			p, err := newProcessor(path, logger)
 			require.NoError(t, err)
 
 			tx, err := p.db.BeginTx(context.Background(), nil)


### PR DESCRIPTION
## Description

- Avoid to log full certificate because it's too long
- Add logs to `bridgesync` creation
- Reduce log for `l1infotreesync/processor.go:401`  `block 7157878 processed with 0 events` in case of 0 events

