### PR TITLE
chore: simplify the `HashMeddler`

### DIFF
--- a/agglayer/types.go
+++ b/agglayer/types.go
@@ -595,7 +595,7 @@ func (c *CertificateHeader) String() string {
 	if c.PreviousLocalExitRoot != nil {
 		previousLocalExitRoot = c.PreviousLocalExitRoot.String()
 	}
-	return fmt.Sprintf("Height: %d, CertificateID: %s, previousLocalExitRoot:%s, NewLocalExitRoot: %s. Status: %s."+
+	return fmt.Sprintf("Height: %d, CertificateID: %s, PreviousLocalExitRoot: %s, NewLocalExitRoot: %s. Status: %s."+
 		" Errors: [%s]",
 		c.Height, c.CertificateID.String(), previousLocalExitRoot, c.NewLocalExitRoot.String(), c.Status.String(), errors)
 }

--- a/agglayer/types_test.go
+++ b/agglayer/types_test.go
@@ -36,7 +36,7 @@ func TestCertificateHeaderString(t *testing.T) {
 		Height:        1,
 		CertificateID: common.HexToHash("0x123"),
 	}
-	require.Equal(t, "Height: 1, CertificateID: 0x0000000000000000000000000000000000000000000000000000000000000123, previousLocalExitRoot:nil, NewLocalExitRoot: 0x0000000000000000000000000000000000000000000000000000000000000000. Status: Pending. Errors: []",
+	require.Equal(t, "Height: 1, CertificateID: 0x0000000000000000000000000000000000000000000000000000000000000123, PreviousLocalExitRoot: nil, NewLocalExitRoot: 0x0000000000000000000000000000000000000000000000000000000000000000. Status: Pending. Errors: []",
 		certificate.String())
 
 	var certNil *CertificateHeader

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -611,7 +611,7 @@ func (a *AggSender) updateCertificateStatus(ctx context.Context,
 
 	// That is a strange situation
 	if agglayerCert.Status.IsOpen() && localCert.Status.IsClosed() {
-		a.log.Warnf("certificate %s is reopen! from [%s] to [%s]",
+		a.log.Warnf("certificate %s is reopened! from [%s] to [%s]",
 			localCert.ID(), localCert.Status, agglayerCert.Status)
 	}
 

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -99,7 +99,7 @@ func (c *CertificateInfo) String() string {
 	)
 }
 
-// ID returns a string with the ident of this cert (height/certID)
+// ID returns a string with the unique identifier of the cerificate (height+certificateID)
 func (c *CertificateInfo) ID() string {
 	if c == nil {
 		return "nil"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hermeznetwork/tracerr v0.3.2
 	github.com/iden3/go-iden3-crypto v0.0.17
 	github.com/invopop/jsonschema v0.12.0
-	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/knadh/koanf/parsers/json v0.1.0
 	github.com/knadh/koanf/parsers/toml v0.1.0
@@ -91,6 +90,7 @@ require (
 	github.com/holiman/uint256 v1.3.1 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.14.3 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect


### PR DESCRIPTION
## Description

This PR simplifies the `HashMeddler` logic a bit, because it supports both nullable and non-nullable fields. Also, fix some logs and minor stuff.
