### PR TITLE
ci: build cdk image once for all e2e test jobs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,6 +31,7 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: build-cdk-image
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.22
+        ref: v0.2.23
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,34 +7,43 @@ on:
 
 
 jobs:
+  build-cdk-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: 1.22.x
+
+    - name: Build cdk docker image
+      run: make build-docker
+    
+    - name: Save cdk image to archive
+      run: docker save --output /tmp/cdk.tar cdk
+    
+    - name: Upload archive
+      uses: actions/upload-artifact@v4
+      with:
+        name: cdk
+        path: /tmp/cdk.tar
+
   test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ 1.22.x ]
-        goarch: [ "amd64" ]
         e2e-group:
           - "fork9-validium"
           - "fork11-rollup"
           - "fork12-validium"
           - "fork12-rollup"
           - "fork12-pessimistic"
-    runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-      env:
-        GOARCH: ${{ matrix.goarch }}
-
-    - name: Build Docker
-      run: make build-docker
+    - uses: actions/checkout@v4
     
-    - name: Checkout kurtosis-cdk
+    - name: Checkout kurtosis-cdk repository
       uses: actions/checkout@v4
       with:
         repository: 0xPolygon/kurtosis-cdk
@@ -54,10 +63,21 @@ jobs:
         sudo chmod +x /usr/local/bin/polycli
         /usr/local/bin/polycli version
 
-    - name: Setup Bats and bats libs
+    - name: Setup bats
       uses: bats-core/bats-action@2.0.0
+    
+    - name: Download cdk archive
+      uses: actions/download-artifact@v4
+      with:
+        name: cdk
+        path: /tmp
+    
+    - name: Load cdk image
+      run: |
+        docker load --input /tmp/cdk.tar
+        docker image ls -a
 
-    - name: Test
+    - name: Run e2e tests
       run: make test-e2e-${{ matrix.e2e-group }}
       working-directory: test
       env:

--- a/.github/workflows/test-resequence.yml
+++ b/.github/workflows/test-resequence.yml
@@ -5,7 +5,6 @@ on:
       # Disable test for the moment as it takes too long
       - "test_disabled"
 
-
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -35,7 +34,7 @@ jobs:
         with:
           repository: 0xPolygon/kurtosis-cdk
           path: kurtosis-cdk
-          ref: v0.2.22
+          ref: v0.2.23
 
       - name: Install Kurtosis CDK tools
         uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
@@ -43,9 +42,9 @@ jobs:
       - name: Install polycli
         run: |
           POLYCLI_VERSION="${{ vars.POLYCLI_VERSION }}"
-          tmp_dir=$(mktemp -d) 
-          curl -L "https://github.com/0xPolygon/polygon-cli/releases/download/${POLYCLI_VERSION}/polycli_${POLYCLI_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$tmp_dir" 
-          mv "$tmp_dir"/* /usr/local/bin/polycli 
+          tmp_dir=$(mktemp -d)
+          curl -L "https://github.com/0xPolygon/polygon-cli/releases/download/${POLYCLI_VERSION}/polycli_${POLYCLI_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$tmp_dir"
+          mv "$tmp_dir"/* /usr/local/bin/polycli
           rm -rf "$tmp_dir"
           sudo chmod +x /usr/local/bin/polycli
           /usr/local/bin/polycli version
@@ -68,7 +67,6 @@ jobs:
           /usr/local/bin/yq -i '.args.zkevm_prover_image = "hermeznetwork/zkevm-prover:v8.0.0-RC5-fork.12"' params.yml
           /usr/local/bin/yq -i '.args.cdk_erigon_node_image = "jerrycgh/cdk-erigon:d5d04906f723f3f1d8c43c9e6baf3e18c27ff348"' params.yml
 
-
       - name: Deploy Kurtosis CDK package
         working-directory: ./kurtosis-cdk
         run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
@@ -80,7 +78,7 @@ jobs:
       - name: Dump enclave logs
         if: failure()
         run: kurtosis dump ./dump
-  
+
       - name: Generate archive name
         if: failure()
         run: |


### PR DESCRIPTION
## Description

Rather than building the `cdk` image in each test job, create it in an initial job and reuse that built image for all subsequent test jobs.

It also bumps to the latest kurtosis-cdk version.

E2E tests pass on my fork: https://github.com/leovct/cdk/actions/runs/12069227043
