### PR TITLE
fix: clean proof table on start

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -354,7 +354,7 @@ func (a *Aggregator) Start() error {
 		// Delete existing proofs
 		err = a.state.DeleteGeneratedProofs(a.ctx, lastVerifiedBatchNumber, maxDBBigIntValue, nil)
 		if err != nil {
-			return fmt.Errorf("failed to initialize proofs cache %w", err)
+			return fmt.Errorf("failed to delete proofs table %w", err)
 		}
 
 		a.resetVerifyProofTime()

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -335,12 +335,6 @@ func (a *Aggregator) Start() error {
 		healthService := newHealthChecker()
 		grpchealth.RegisterHealthServer(a.srv, healthService)
 
-		// Delete ungenerated recursive proofs
-		err = a.state.DeleteUngeneratedProofs(a.ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to initialize proofs cache %w", err)
-		}
-
 		// Get last verified batch number to set the starting point for verifications
 		lastVerifiedBatchNumber, err := a.etherman.GetLatestVerifiedBatchNum()
 		if err != nil {
@@ -356,6 +350,12 @@ func (a *Aggregator) Start() error {
 
 		a.logger.Infof("Starting AccInputHash:%v", accInputHash.String())
 		a.setAccInputHash(lastVerifiedBatchNumber, *accInputHash)
+
+		// Delete existing proofs
+		err = a.state.DeleteGeneratedProofs(a.ctx, lastVerifiedBatchNumber, maxDBBigIntValue, nil)
+		if err != nil {
+			return fmt.Errorf("failed to initialize proofs cache %w", err)
+		}
 
 		a.resetVerifyProofTime()
 

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -83,7 +83,7 @@ func Test_Start(t *testing.T) {
 	mockL1Syncr.On("Sync", mock.Anything).Return(nil)
 	mockEtherman.On("GetLatestVerifiedBatchNum").Return(uint64(90), nil).Once()
 	mockEtherman.On("GetBatchAccInputHash", mock.Anything, uint64(90)).Return(common.Hash{}, nil).Once()
-	mockState.On("DeleteUngeneratedProofs", mock.Anything, nil).Return(nil).Once()
+	mockState.On("DeleteGeneratedProofs", mock.Anything, uint64(90), mock.Anything, nil).Return(nil).Once()
 	mockState.On("CleanupLockedProofs", mock.Anything, "", nil).Return(int64(0), nil)
 
 	mockEthTxManager.On("Start").Return(nil)


### PR DESCRIPTION
## Description

Cleans proof table on aggregator start to ensure all the acc input hash is properly calculated for all pending batches.

Fixes #201 
