### PR TITLE
feat: write on database the number of retries per certificate and the certificates in a history table

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -33,26 +33,17 @@ jobs:
 
     - name: Build Docker
       run: make build-docker
- 
-      # this is better to get the action in
-    - name: Install kurtosis
-      shell: bash
-      run: |
-        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-        sudo apt update
-        sudo apt install kurtosis-cli=1.4.1
-        kurtosis version
-
-    - name: Disable kurtosis analytics
-      shell: bash
-      run: kurtosis analytics disable
-
-    - name: Install yq
-      shell: bash
-      run: |
-        pip3 install yq
-        yq --version
-
+    
+    - name: Checkout kurtosis-cdk
+      uses: actions/checkout@v4
+      with:
+        repository: 0xPolygon/kurtosis-cdk
+        path: kurtosis-cdk
+        ref: v0.2.22
+    
+    - name: Install Kurtosis CDK tools
+      uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
+    
     - name: Install polycli
       run: |
         POLYCLI_VERSION="${{ vars.POLYCLI_VERSION }}"
@@ -62,16 +53,6 @@ jobs:
         rm -rf "$tmp_dir"
         sudo chmod +x /usr/local/bin/polycli
         /usr/local/bin/polycli version
-
-    - name: Install foundry
-      uses: foundry-rs/foundry-toolchain@v1
-
-    - name: checkout kurtosis-cdk
-      uses: actions/checkout@v4
-      with:
-        repository: 0xPolygon/kurtosis-cdk
-        path: "kurtosis-cdk"
-        ref: "v0.2.21"
 
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.22
+        ref: v0.2.23
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.23
+        ref: v0.2.24
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-resequence.yml
+++ b/.github/workflows/test-resequence.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: 0xPolygon/kurtosis-cdk
           path: kurtosis-cdk
-          ref: v0.2.22
+          ref: v0.2.23
 
       - name: Install Kurtosis CDK tools
         uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-resequence.yml
+++ b/.github/workflows/test-resequence.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: cdk
 
-      - name: Checkout kurtosis-cdk
+      - name: Checkout cdk-erigon
         uses: actions/checkout@v4
         with:
           repository: 0xPolygonHermez/cdk-erigon
@@ -34,20 +34,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 0xPolygon/kurtosis-cdk
-          ref: a7a80b7b5d98a69a23415ab0018e556257a6dfb6
           path: kurtosis-cdk
+          ref: v0.2.22
 
       - name: Install Kurtosis CDK tools
         uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Install yq
-        run: |
-          sudo curl -L https://github.com/mikefarah/yq/releases/download/v4.44.2/yq_linux_amd64 -o /usr/local/bin/yq
-          sudo chmod +x /usr/local/bin/yq
-          /usr/local/bin/yq --version
 
       - name: Install polycli
         run: |

--- a/.github/workflows/test-resequence.yml
+++ b/.github/workflows/test-resequence.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: 0xPolygon/kurtosis-cdk
           path: kurtosis-cdk
-          ref: v0.2.23
+          ref: v0.2.24
 
       - name: Install Kurtosis CDK tools
         uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -1951,7 +1951,11 @@ func newAggsenderTestData(t *testing.T, creationFlags testDataFlags) *aggsenderT
 		pc, _, _, _ := runtime.Caller(1)
 		part := runtime.FuncForPC(pc)
 		dbPath := fmt.Sprintf("file:%d?mode=memory&cache=shared", part.Entry())
-		storage, err = db.NewAggSenderSQLStorage(logger, dbPath)
+		storageConfig := db.AggSenderSQLStorageConfig{
+			DBPath:                  dbPath,
+			KeepCertificatesHistory: true,
+		}
+		storage, err = db.NewAggSenderSQLStorage(logger, storageConfig)
 		require.NoError(t, err)
 	}
 

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	// DelayBeetweenRetries is the delay between retries:
 	//  is used on store Certificate and also in initial check
 	DelayBeetweenRetries types.Duration `mapstructure:"DelayBeetweenRetries"`
+	// KeepCertificatesHistory is a flag to keep the certificates history on storage
+	KeepCertificatesHistory bool `mapstructure:"KeepCertificatesHistory"`
 }
 
 // String returns a string representation of the Config

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -36,26 +36,33 @@ type AggSenderStorage interface {
 
 var _ AggSenderStorage = (*AggSenderSQLStorage)(nil)
 
+// AggSenderSQLStorageConfig is the configuration for the AggSenderSQLStorage
+type AggSenderSQLStorageConfig struct {
+	DBPath                  string
+	KeepCertificatesHistory bool
+}
+
 // AggSenderSQLStorage is the struct that implements the AggSenderStorage interface
 type AggSenderSQLStorage struct {
 	logger *log.Logger
 	db     *sql.DB
+	cfg    AggSenderSQLStorageConfig
 }
 
 // NewAggSenderSQLStorage creates a new AggSenderSQLStorage
-func NewAggSenderSQLStorage(logger *log.Logger, dbPath string) (*AggSenderSQLStorage, error) {
-	if err := migrations.RunMigrations(dbPath); err != nil {
+func NewAggSenderSQLStorage(logger *log.Logger, cfg AggSenderSQLStorageConfig) (*AggSenderSQLStorage, error) {
+	db, err := db.NewSQLiteDB(cfg.DBPath)
+	if err != nil {
 		return nil, err
 	}
-
-	db, err := db.NewSQLiteDB(dbPath)
-	if err != nil {
+	if err := migrations.RunMigrations(logger, db); err != nil {
 		return nil, err
 	}
 
 	return &AggSenderSQLStorage{
 		db:     db,
 		logger: logger,
+		cfg:    cfg,
 	}, nil
 }
 
@@ -93,7 +100,7 @@ func (a *AggSenderSQLStorage) GetCertificateByHeight(height uint64) (*types.Cert
 }
 
 // getCertificateByHeight returns a certificate by its height using the provided db
-func getCertificateByHeight(db meddler.DB,
+func getCertificateByHeight(db db.Querier,
 	height uint64) (*types.CertificateInfo, error) {
 	var certificateInfo types.CertificateInfo
 	if err := meddler.QueryRow(db, &certificateInfo,
@@ -119,7 +126,7 @@ func (a *AggSenderSQLStorage) GetLastSentCertificate() (*types.CertificateInfo, 
 func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certificate types.CertificateInfo) error {
 	tx, err := db.NewTx(ctx, a.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("saveLastSentCertificate NewTx. Err: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -131,14 +138,14 @@ func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certi
 
 	cert, err := getCertificateByHeight(tx, certificate.Height)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
-		return err
+		return fmt.Errorf("saveLastSentCertificate getCertificateByHeight. Err: %w", err)
 	}
 
 	if cert != nil {
 		// we already have a certificate with this height
 		// we need to delete it before inserting the new one
-		if err = deleteCertificate(tx, cert.CertificateID); err != nil {
-			return err
+		if err = a.moveCertificateToHistory(tx, cert); err != nil {
+			return fmt.Errorf("saveLastSentCertificate moveCertificateToHistory Err: %w", err)
 		}
 	}
 
@@ -147,10 +154,26 @@ func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certi
 	}
 
 	if err = tx.Commit(); err != nil {
-		return err
+		return fmt.Errorf("saveLastSentCertificate commit. Err: %w", err)
 	}
 
 	a.logger.Debugf("inserted certificate - Height: %d. Hash: %s", certificate.Height, certificate.CertificateID)
+
+	return nil
+}
+
+func (a *AggSenderSQLStorage) moveCertificateToHistory(tx db.Querier, certificate *types.CertificateInfo) error {
+	if a.cfg.KeepCertificatesHistory {
+		a.logger.Debugf("moving certificate to history - new CertificateID: %s", certificate.ID())
+		if _, err := tx.Exec(`INSERT INTO certificate_info_history SELECT * FROM certificate_info WHERE height = $1;`,
+			certificate.Height); err != nil {
+			return fmt.Errorf("error moving certificate to history: %w", err)
+		}
+	}
+	a.logger.Debugf("deleting certificate - CertificateID: %s", certificate.ID())
+	if err := deleteCertificate(tx, certificate.CertificateID); err != nil {
+		return fmt.Errorf("deleteCertificate %s . Error: %w", certificate.ID(), err)
+	}
 
 	return nil
 }
@@ -169,7 +192,7 @@ func (a *AggSenderSQLStorage) DeleteCertificate(ctx context.Context, certificate
 		}
 	}()
 
-	if err = deleteCertificate(a.db, certificateID); err != nil {
+	if err = deleteCertificate(tx, certificateID); err != nil {
 		return err
 	}
 
@@ -183,8 +206,8 @@ func (a *AggSenderSQLStorage) DeleteCertificate(ctx context.Context, certificate
 }
 
 // deleteCertificate deletes a certificate from the storage using the provided db
-func deleteCertificate(db meddler.DB, certificateID common.Hash) error {
-	if _, err := db.Exec(`DELETE FROM certificate_info WHERE certificate_id = $1;`, certificateID.String()); err != nil {
+func deleteCertificate(tx db.Querier, certificateID common.Hash) error {
+	if _, err := tx.Exec(`DELETE FROM certificate_info WHERE certificate_id = $1;`, certificateID.String()); err != nil {
 		return fmt.Errorf("error deleting certificate info: %w", err)
 	}
 
@@ -205,8 +228,8 @@ func (a *AggSenderSQLStorage) UpdateCertificate(ctx context.Context, certificate
 		}
 	}()
 
-	if _, err = tx.Exec(`UPDATE certificate_info SET status = $1 WHERE certificate_id = $2;`,
-		certificate.Status, certificate.CertificateID.String()); err != nil {
+	if _, err = tx.Exec(`UPDATE certificate_info SET status = $1, updated_at=$2 WHERE certificate_id = $3;`,
+		certificate.Status, certificate.UpdatedAt, certificate.CertificateID.String()); err != nil {
 		return fmt.Errorf("error updating certificate info: %w", err)
 	}
 	if err = tx.Commit(); err != nil {

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -162,7 +162,8 @@ func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certi
 	return nil
 }
 
-func (a *AggSenderSQLStorage) moveCertificateToHistoryOrDelete(tx db.Querier, certificate *types.CertificateInfo) error {
+func (a *AggSenderSQLStorage) moveCertificateToHistoryOrDelete(tx db.Querier,
+	certificate *types.CertificateInfo) error {
 	if a.cfg.KeepCertificatesHistory {
 		a.logger.Debugf("moving certificate to history - new CertificateID: %s", certificate.ID())
 		if _, err := tx.Exec(`INSERT INTO certificate_info_history SELECT * FROM certificate_info WHERE height = $1;`,

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -228,7 +228,7 @@ func (a *AggSenderSQLStorage) UpdateCertificate(ctx context.Context, certificate
 		}
 	}()
 
-	if _, err = tx.Exec(`UPDATE certificate_info SET status = $1, updated_at=$2 WHERE certificate_id = $3;`,
+	if _, err = tx.Exec(`UPDATE certificate_info SET status = $1, updated_at = $2 WHERE certificate_id = $3;`,
 		certificate.Status, certificate.UpdatedAt, certificate.CertificateID.String()); err != nil {
 		return fmt.Errorf("error updating certificate info: %w", err)
 	}

--- a/aggsender/db/aggsender_db_storage.go
+++ b/aggsender/db/aggsender_db_storage.go
@@ -144,7 +144,7 @@ func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certi
 	if cert != nil {
 		// we already have a certificate with this height
 		// we need to delete it before inserting the new one
-		if err = a.moveCertificateToHistory(tx, cert); err != nil {
+		if err = a.moveCertificateToHistoryOrDelete(tx, cert); err != nil {
 			return fmt.Errorf("saveLastSentCertificate moveCertificateToHistory Err: %w", err)
 		}
 	}
@@ -162,7 +162,7 @@ func (a *AggSenderSQLStorage) SaveLastSentCertificate(ctx context.Context, certi
 	return nil
 }
 
-func (a *AggSenderSQLStorage) moveCertificateToHistory(tx db.Querier, certificate *types.CertificateInfo) error {
+func (a *AggSenderSQLStorage) moveCertificateToHistoryOrDelete(tx db.Querier, certificate *types.CertificateInfo) error {
 	if a.cfg.KeepCertificatesHistory {
 		a.logger.Debugf("moving certificate to history - new CertificateID: %s", certificate.ID())
 		if _, err := tx.Exec(`INSERT INTO certificate_info_history SELECT * FROM certificate_info WHERE height = $1;`,

--- a/aggsender/db/migrations/0001.sql
+++ b/aggsender/db/migrations/0001.sql
@@ -1,10 +1,13 @@
 -- +migrate Down
 DROP TABLE IF EXISTS certificate_info;
+DROP TABLE IF EXISTS certificate_info_history;
+DROP TABLE IF EXISTS certificate_info_history;
 
 -- +migrate Up
 CREATE TABLE certificate_info (
     height                      INTEGER NOT NULL,
-    certificate_id              VARCHAR NOT NULL PRIMARY KEY,
+    retry_count                 INTEGER DEFAULT 0, 
+    certificate_id              VARCHAR NOT NULL,
     status                      INTEGER NOT NULL,
     previous_local_exit_root    VARCHAR,
     new_local_exit_root         VARCHAR NOT NULL,
@@ -12,5 +15,21 @@ CREATE TABLE certificate_info (
     to_block                    INTEGER NOT NULL,
     created_at                  INTEGER NOT NULL,
     updated_at                  INTEGER NOT NULL,
-    signed_certificate          TEXT
+    signed_certificate          TEXT,
+    PRIMARY KEY (height)
+);
+
+CREATE TABLE certificate_info_history (
+    height                      INTEGER NOT NULL ,
+    retry_count                 INTEGER DEFAULT 0,  
+    certificate_id              VARCHAR NOT NULL,
+    status                      INTEGER NOT NULL,
+    previous_local_exit_root    VARCHAR,
+    new_local_exit_root         VARCHAR NOT NULL,
+    from_block                  INTEGER NOT NULL,
+    to_block                    INTEGER NOT NULL,
+    created_at                  INTEGER NOT NULL,
+    updated_at                  INTEGER NOT NULL,
+    signed_certificate          TEXT,
+    PRIMARY KEY (height, retry_count)
 );

--- a/aggsender/db/migrations/migrations.go
+++ b/aggsender/db/migrations/migrations.go
@@ -1,16 +1,18 @@
 package migrations
 
 import (
+	"database/sql"
 	_ "embed"
 
 	"github.com/0xPolygon/cdk/db"
 	"github.com/0xPolygon/cdk/db/types"
+	"github.com/0xPolygon/cdk/log"
 )
 
 //go:embed 0001.sql
 var mig001 string
 
-func RunMigrations(dbPath string) error {
+func RunMigrations(logger *log.Logger, database *sql.DB) error {
 	migrations := []types.Migration{
 		{
 			ID:  "0001",
@@ -18,5 +20,5 @@ func RunMigrations(dbPath string) error {
 		},
 	}
 
-	return db.RunMigrations(dbPath, migrations)
+	return db.RunMigrationsDB(logger, database, migrations)
 }

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -80,6 +80,7 @@ func (c *CertificateInfo) String() string {
 	}
 	return fmt.Sprintf("aggsender.CertificateInfo: "+
 		"Height: %d "+
+		"RetryCount: %d "+
 		"CertificateID: %s "+
 		"PreviousLocalExitRoot: %s "+
 		"NewLocalExitRoot: %s "+

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -56,6 +56,7 @@ type Logger interface {
 
 type CertificateInfo struct {
 	Height        uint64      `meddler:"height"`
+	RetryCount    int         `meddler:"retry_count"`
 	CertificateID common.Hash `meddler:"certificate_id,hash"`
 	// PreviousLocalExitRoot if it's nil means no reported
 	PreviousLocalExitRoot *common.Hash               `meddler:"previous_local_exit_root,hash"`
@@ -88,6 +89,7 @@ func (c *CertificateInfo) String() string {
 		"CreatedAt: %s "+
 		"UpdatedAt: %s",
 		c.Height,
+		c.RetryCount,
 		c.CertificateID.String(),
 		previousLocalExitRoot,
 		c.NewLocalExitRoot.String(),
@@ -104,7 +106,7 @@ func (c *CertificateInfo) ID() string {
 	if c == nil {
 		return "nil"
 	}
-	return fmt.Sprintf("%d/%s", c.Height, c.CertificateID.String())
+	return fmt.Sprintf("%d/%s (retry %d)", c.Height, c.CertificateID.String(), c.RetryCount)
 }
 
 // IsClosed returns true if the certificate is closed (settled or inError)

--- a/config/default.go
+++ b/config/default.go
@@ -339,4 +339,5 @@ EpochNotificationPercentage = 50
 SaveCertificatesToFilesPath = ""
 MaxRetriesStoreCertificate = 3
 DelayBeetweenRetries = "60s"
+KeepCertificatesHistory = true
 `

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -23,6 +24,10 @@ func RunMigrations(dbPath string, migrations []types.Migration) error {
 	if err != nil {
 		return fmt.Errorf("error creating DB %w", err)
 	}
+	return RunMigrationsDB(log.GetDefaultLogger(), db, migrations)
+}
+
+func RunMigrationsDB(logger *log.Logger, db *sql.DB, migrations []types.Migration) error {
 	migs := &migrate.MemoryMigrationSource{Migrations: []*migrate.Migration{}}
 	for _, m := range migrations {
 		prefixed := strings.ReplaceAll(m.SQL, dbPrefixReplacer, m.Prefix)
@@ -34,15 +39,15 @@ func RunMigrations(dbPath string, migrations []types.Migration) error {
 		})
 	}
 
-	log.Debugf("running migrations:")
+	logger.Debugf("running migrations:")
 	for _, m := range migs.Migrations {
-		log.Debugf("%+v", m.Id)
+		logger.Debugf("%+v", m.Id)
 	}
 	nMigrations, err := migrate.Exec(db, "sqlite3", migs, migrate.Up)
 	if err != nil {
 		return fmt.Errorf("error executing migration %w", err)
 	}
 
-	log.Infof("successfully ran %d migrations", nMigrations)
+	logger.Infof("successfully ran %d migrations", nMigrations)
 	return nil
 }

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -4,7 +4,6 @@ args:
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   data_availability_mode: rollup
   sequencer_type: erigon
-  

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
+  zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -3,8 +3,6 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   data_availability_mode: cdk-validium
   sequencer_type: erigon
-  
-

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -10,6 +10,6 @@ args:
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}
   enable_normalcy: true

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -5,7 +5,7 @@ args:
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
-  zkevm_contracts_image: nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -5,7 +5,7 @@ args:
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
-  zkevm_contracts_image: nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12
+  zkevm_contracts_image: nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -3,6 +3,6 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   data_availability_mode: rollup
   sequencer_type: erigon

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -5,7 +5,7 @@ args:
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   additional_services:
     - pless_zkevm_node
   data_availability_mode: cdk-validium

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
+  zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1


### PR DESCRIPTION
## Description

- Add new field `retries` to database, that keep the count of times of regenerated the certificate
- The discarded certificates are move (if configuration allow that) to a new table `certificate_info_history`
- Cherry-picked #202 to fix e2e-test

## Configuration
```
[AggSender]
KeepCertificatesHistory = true
```
## Next steps
- Define the retain policy