### PR TITLE
refactor: encode metadata to be backwards compatible

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -195,6 +195,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 		ToBlock:   toBlock,
 		Bridges:   bridges,
 		Claims:    claims,
+		CreatedAt: uint32(time.Now().UTC().Unix()),
 	}
 
 	certificateParams, err = a.limitCertSize(certificateParams)
@@ -228,7 +229,6 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 		return nil, fmt.Errorf("error marshalling signed certificate. Cert:%s. Err: %w", signedCertificate.Brief(), err)
 	}
 
-	createdTime := time.Now().UTC().UnixMilli()
 	prevLER := common.BytesToHash(certificate.PrevLocalExitRoot[:])
 	certInfo := types.CertificateInfo{
 		Height:                certificate.Height,
@@ -238,8 +238,8 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 		PreviousLocalExitRoot: &prevLER,
 		FromBlock:             fromBlock,
 		ToBlock:               toBlock,
-		CreatedAt:             createdTime,
-		UpdatedAt:             createdTime,
+		CreatedAt:             int64(certificateParams.CreatedAt),
+		UpdatedAt:             int64(certificateParams.CreatedAt),
 		SignedCertificate:     string(raw),
 	}
 	// TODO: Improve this case, if a cert is not save in the storage, we are going to settle a unknown certificate
@@ -396,7 +396,7 @@ func (a *AggSender) buildCertificate(ctx context.Context,
 	meta := types.NewCertificateMetadata(
 		certParams.FromBlock,
 		uint32(certParams.ToBlock-certParams.FromBlock),
-		uint32(time.Now().UTC().Unix()),
+		certParams.CreatedAt,
 	)
 
 	return &agglayer.Certificate{

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -381,7 +381,7 @@ func (a *AggSender) buildCertificate(ctx context.Context,
 		return nil, fmt.Errorf("error getting imported bridge exits: %w", err)
 	}
 
-	depositCount := certParams.MaxDepoitCount()
+	depositCount := certParams.MaxDepositCount()
 
 	exitRoot, err := a.l2Syncer.GetExitRootByIndex(ctx, depositCount)
 	if err != nil {

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -394,7 +394,11 @@ func (a *AggSender) buildCertificate(ctx context.Context,
 		return nil, fmt.Errorf("error getting next height and previous LER: %w", err)
 	}
 
-	meta := types.NewCertificateMetadata(fromBlock, toBlock, createdAt)
+	meta := types.NewCertificateMetadata(
+		certParams.FromBlock,
+		certParams.ToBlock,
+		uint64(time.Now().UTC().UnixMilli()),
+	)
 
 	return &agglayer.Certificate{
 		NetworkID:           a.l2Syncer.OriginNetwork(),
@@ -403,7 +407,7 @@ func (a *AggSender) buildCertificate(ctx context.Context,
 		BridgeExits:         bridgeExits,
 		ImportedBridgeExits: importedBridgeExits,
 		Height:              height,
-		Metadata:            createCertificateMetadata(certParams.ToBlock),
+		Metadata:            meta.ToHash(),
 	}, nil
 }
 

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -780,13 +780,17 @@ func NewCertificateInfoFromAgglayerCertHeader(c *agglayer.CertificateHeader) *ty
 	}
 	now := time.Now().UTC().UnixMilli()
 	meta := types.NewCertificateMetadataFromHash(c.Metadata)
+	toBlock := meta.FromBlock + uint64(meta.Offset)
+	if meta.Version < 1 {
+		toBlock = meta.ToBlock
+	}
 
 	res := &types.CertificateInfo{
 		Height:            c.Height,
 		CertificateID:     c.CertificateID,
 		NewLocalExitRoot:  c.NewLocalExitRoot,
 		FromBlock:         meta.FromBlock,
-		ToBlock:           meta.FromBlock + uint64(meta.Offset),
+		ToBlock:           toBlock,
 		Status:            c.Status,
 		CreatedAt:         int64(meta.CreatedAt),
 		UpdatedAt:         now,

--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -394,6 +394,8 @@ func (a *AggSender) buildCertificate(ctx context.Context,
 		return nil, fmt.Errorf("error getting next height and previous LER: %w", err)
 	}
 
+	meta := types.NewCertificateMetadata(fromBlock, toBlock, createdAt)
+
 	return &agglayer.Certificate{
 		NetworkID:           a.l2Syncer.OriginNetwork(),
 		PrevLocalExitRoot:   previousLER,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -1713,8 +1713,9 @@ func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 	}{
 		{
 			name:     "Valid metadata",
-			metadata: aggsendertypes.NewCertificateMetadata(0, 123567890, 123567890).ToHash(),
+			metadata: aggsendertypes.NewCertificateMetadata(0, 1000, 123567890).ToHash(),
 			expected: aggsendertypes.CertificateMetadata{
+				Version:   1,
 				FromBlock: 0,
 				Offset:    1000,
 				CreatedAt: 123567890,
@@ -1724,6 +1725,7 @@ func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 			name:     "Zero metadata",
 			metadata: aggsendertypes.NewCertificateMetadata(0, 0, 0).ToHash(),
 			expected: aggsendertypes.CertificateMetadata{
+				Version:   1,
 				FromBlock: 0,
 				Offset:    0,
 				CreatedAt: 0,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -631,7 +631,7 @@ func TestBuildCertificate(t *testing.T) {
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
-				Metadata:          aggsendertypes.NewCertificateMetadata(0, 10, 0).ToHash(),
+				Metadata:          aggsendertypes.NewCertificateMetadata(0, 10, uint32(time.Now().Unix())).ToHash(),
 				BridgeExits: []*agglayer.BridgeExit{
 					{
 						LeafType: agglayer.LeafTypeAsset,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -2022,7 +2022,7 @@ func certInfoToCertHeader(t *testing.T, certInfo *aggsendertypes.CertificateInfo
 		Metadata: aggsendertypes.NewCertificateMetadata(
 			certInfo.FromBlock,
 			uint32(certInfo.FromBlock-certInfo.ToBlock),
-			uint32(certInfo.CreatedAt),
+			certInfo.CreatedAt,
 		).ToHash(),
 	}
 }

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -1703,13 +1703,6 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 	mockL1InfoTreeSyncer.AssertExpectations(t)
 }
 
-func TestMetadataConversions(t *testing.T) {
-	toBlock := uint64(123567890)
-	c := createCertificateMetadata(toBlock)
-	extractBlock := extractFromCertificateMetadataToBlock(c)
-	require.Equal(t, toBlock, extractBlock)
-}
-
 func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 	t.Parallel()
 

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -1709,22 +1709,25 @@ func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 	tests := []struct {
 		name     string
 		metadata common.Hash
-		expected uint64
+		expected aggsendertypes.CertificateMetadata
 	}{
 		{
 			name:     "Valid metadata",
-			metadata: common.BigToHash(big.NewInt(123567890)),
-			expected: 123567890,
+			metadata: aggsendertypes.NewCertificateMetadata(0, 123567890, 123567890).ToHash(),
+			expected: aggsendertypes.CertificateMetadata{
+				FromBlock: 0,
+				Offset:    1000,
+				CreatedAt: 123567890,
+			},
 		},
 		{
 			name:     "Zero metadata",
-			metadata: common.BigToHash(big.NewInt(0)),
-			expected: 0,
-		},
-		{
-			name:     "Max uint64 metadata",
-			metadata: common.BigToHash(new(big.Int).SetUint64(^uint64(0))),
-			expected: ^uint64(0),
+			metadata: aggsendertypes.NewCertificateMetadata(0, 0, 0).ToHash(),
+			expected: aggsendertypes.CertificateMetadata{
+				FromBlock: 0,
+				Offset:    0,
+				CreatedAt: 0,
+			},
 		},
 	}
 
@@ -1734,7 +1737,7 @@ func TestExtractFromCertificateMetadataToBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := extractFromCertificateMetadataToBlock(tt.metadata)
+			result := *aggsendertypes.NewCertificateMetadataFromHash(tt.metadata)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -2014,7 +2017,11 @@ func certInfoToCertHeader(t *testing.T, certInfo *aggsendertypes.CertificateInfo
 		CertificateID:    certInfo.CertificateID,
 		NewLocalExitRoot: certInfo.NewLocalExitRoot,
 		Status:           agglayer.Pending,
-		Metadata:         createCertificateMetadata(certInfo.ToBlock),
+		Metadata: aggsendertypes.NewCertificateMetadata(
+			certInfo.FromBlock,
+			uint32(certInfo.FromBlock-certInfo.ToBlock),
+			uint32(certInfo.CreatedAt),
+		).ToHash(),
 	}
 }
 

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -631,7 +631,7 @@ func TestBuildCertificate(t *testing.T) {
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
-				Metadata:          aggsendertypes.NewCertificateMetadata(0, 10, uint32(time.Now().Unix())).ToHash(),
+				Metadata:          aggsendertypes.NewCertificateMetadata(0, 10, 0).ToHash(),
 				BridgeExits: []*agglayer.BridgeExit{
 					{
 						LeafType: agglayer.LeafTypeAsset,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -631,7 +631,7 @@ func TestBuildCertificate(t *testing.T) {
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
-				Metadata:          aggsendertypes.NewCertificateMetadata(10, 0, 0).ToHash(),
+				Metadata:          aggsendertypes.NewCertificateMetadata(0, 10, 0).ToHash(),
 				BridgeExits: []*agglayer.BridgeExit{
 					{
 						LeafType: agglayer.LeafTypeAsset,

--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -631,7 +631,7 @@ func TestBuildCertificate(t *testing.T) {
 				NetworkID:         1,
 				PrevLocalExitRoot: common.HexToHash("0x123"),
 				NewLocalExitRoot:  common.HexToHash("0x789"),
-				Metadata:          createCertificateMetadata(10),
+				Metadata:          aggsendertypes.NewCertificateMetadata(10, 0, 0).ToHash(),
 				BridgeExits: []*agglayer.BridgeExit{
 					{
 						LeafType: agglayer.LeafTypeAsset,

--- a/aggsender/db/aggsender_db_storage_test.go
+++ b/aggsender/db/aggsender_db_storage_test.go
@@ -29,7 +29,7 @@ func Test_Storage(t *testing.T) {
 	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
 	require.NoError(t, err)
 
-	updateTime := time.Now().UTC().UnixMilli()
+	updateTime := uint32(time.Now().UTC().UnixMilli())
 
 	t.Run("SaveLastSentCertificate", func(t *testing.T) {
 		certificate := types.CertificateInfo{
@@ -242,7 +242,7 @@ func Test_SaveLastSentCertificate(t *testing.T) {
 	storage, err := NewAggSenderSQLStorage(log.WithFields("aggsender-db"), cfg)
 	require.NoError(t, err)
 
-	updateTime := time.Now().UTC().UnixMilli()
+	updateTime := uint32(time.Now().UTC().UnixMilli())
 
 	t.Run("SaveNewCertificate", func(t *testing.T) {
 		certificate := types.CertificateInfo{

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -93,7 +93,7 @@ func (c *CertificateBuildParams) IsEmpty() bool {
 }
 
 // MaxDepoitCount returns the maximum deposit count in the certificate
-func (c *CertificateBuildParams) MaxDepoitCount() uint32 {
+func (c *CertificateBuildParams) MaxDepositCount() uint32 {
 	if c == nil || c.NumberOfBridges() == 0 {
 		return 0
 	}

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -17,11 +17,12 @@ type CertificateBuildParams struct {
 	ToBlock   uint64
 	Bridges   []bridgesync.Bridge
 	Claims    []bridgesync.Claim
+	CreatedAt uint32
 }
 
 func (c *CertificateBuildParams) String() string {
-	return fmt.Sprintf("FromBlock: %d, ToBlock: %d, numBridges: %d, numClaims: %d",
-		c.FromBlock, c.ToBlock, c.NumberOfBridges(), c.NumberOfClaims())
+	return fmt.Sprintf("FromBlock: %d, ToBlock: %d, numBridges: %d, numClaims: %d, createdAt: %d",
+		c.FromBlock, c.ToBlock, c.NumberOfBridges(), c.NumberOfClaims(), c.CreatedAt)
 }
 
 // Range create a new CertificateBuildParams with the given range

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -65,8 +65,8 @@ type CertificateInfo struct {
 	FromBlock             uint64                     `meddler:"from_block"`
 	ToBlock               uint64                     `meddler:"to_block"`
 	Status                agglayer.CertificateStatus `meddler:"status"`
-	CreatedAt             int64                      `meddler:"created_at"`
-	UpdatedAt             int64                      `meddler:"updated_at"`
+	CreatedAt             uint32                     `meddler:"created_at"`
+	UpdatedAt             uint32                     `meddler:"updated_at"`
 	SignedCertificate     string                     `meddler:"signed_certificate"`
 }
 
@@ -98,8 +98,8 @@ func (c *CertificateInfo) String() string {
 		c.Status.String(),
 		c.FromBlock,
 		c.ToBlock,
-		time.UnixMilli(c.CreatedAt),
-		time.UnixMilli(c.UpdatedAt),
+		time.Unix(int64(c.CreatedAt), 0),
+		time.Unix(int64(c.UpdatedAt), 0),
 	)
 }
 
@@ -124,7 +124,7 @@ func (c *CertificateInfo) ElapsedTimeSinceCreation() time.Duration {
 	if c == nil {
 		return 0
 	}
-	return time.Now().UTC().Sub(time.UnixMilli(c.CreatedAt))
+	return time.Now().UTC().Sub(time.Unix(int64(c.CreatedAt), 0))
 }
 
 type CertificateMetadata struct {

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -134,7 +134,7 @@ type CertificateMetadata struct {
 }
 
 // NewCertificateMetadataFromHash returns a new CertificateMetadata from the given hash
-func NewCertificateMetadata(toBlock, fromBlock, createdAt uint64) *CertificateMetadata {
+func NewCertificateMetadata(fromBlock, toBlock, createdAt uint64) *CertificateMetadata {
 	return &CertificateMetadata{
 		FromBlock: fromBlock,
 		ToBlock:   toBlock,
@@ -147,8 +147,8 @@ func NewCertificateMetadataFromHash(hash common.Hash) *CertificateMetadata {
 	b := hash.Bytes()
 
 	return NewCertificateMetadata(
-		binary.BigEndian.Uint64(b[24:32]),
 		binary.BigEndian.Uint64(b[16:24]),
+		binary.BigEndian.Uint64(b[24:32]),
 		binary.BigEndian.Uint64(b[8:16]),
 	)
 }
@@ -156,6 +156,11 @@ func NewCertificateMetadataFromHash(hash common.Hash) *CertificateMetadata {
 // ToHash returns the hash of the metadata
 func (c *CertificateMetadata) ToHash() common.Hash {
 	b := make([]byte, common.HashLength) // 32-byte hash
+
+	// We encode the metadata with padding 0's at the start,
+	// because previous versions of the code stored the toBlock
+	// at the end of the hash, and we need to be able to decode
+	// those hashes.
 
 	// Encode createdAt
 	binary.BigEndian.PutUint64(b[8:16], c.CreatedAt)

--- a/aggsender/types/types.go
+++ b/aggsender/types/types.go
@@ -128,10 +128,21 @@ func (c *CertificateInfo) ElapsedTimeSinceCreation() time.Duration {
 }
 
 type CertificateMetadata struct {
-	FromBlock uint64 `json:"fromBlock"`
-	Offset    uint32 `json:"toBlock"`
-	CreatedAt uint32 `json:"createdAt"`
-	Version   uint8  `json:"version"`
+	// ToBlock contains the pre v1 value stored in the metadata certificate field
+	// is not stored in the hash post v1
+	ToBlock uint64
+
+	// FromBlock is the block number from which the certificate contains data
+	FromBlock uint64
+
+	// Offset is the number of blocks from the FromBlock that the certificate contains
+	Offset uint32
+
+	// CreatedAt is the timestamp when the certificate was created
+	CreatedAt uint32
+
+	// Version is the version of the metadata
+	Version uint8
 }
 
 // NewCertificateMetadataFromHash returns a new CertificateMetadata from the given hash
@@ -149,13 +160,8 @@ func NewCertificateMetadataFromHash(hash common.Hash) *CertificateMetadata {
 	b := hash.Bytes()
 
 	if b[0] < 1 {
-		hash.Big().Uint64()
-
 		return &CertificateMetadata{
-			Version:   b[0],
-			FromBlock: binary.BigEndian.Uint64(b[1:9]),
-			Offset:    binary.BigEndian.Uint32(b[9:13]),
-			CreatedAt: binary.BigEndian.Uint32(b[13:17]),
+			ToBlock: hash.Big().Uint64(),
 		}
 	}
 

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataConversions_toBlock_Only(t *testing.T) {
+	toBlock := uint64(123567890)
+	hash := common.BigToHash(new(big.Int).SetUint64(toBlock))
+	extractBlock := NewCertificateMetadataFromHash(hash)
+	require.Equal(t, toBlock, extractBlock.ToBlock)
+}
+
+func TestMetadataConversions(t *testing.T) {
+	fromBlock := uint64(123567890)
+	toBlock := uint64(123567890)
+	createdAt := uint64(0)
+	meta := NewCertificateMetadata(fromBlock, toBlock, createdAt)
+	c := meta.ToHash()
+	extractBlock := NewCertificateMetadataFromHash(c)
+	require.Equal(t, fromBlock, extractBlock.FromBlock)
+	require.Equal(t, toBlock, extractBlock.ToBlock)
+	require.Equal(t, createdAt, extractBlock.CreatedAt)
+}

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -12,17 +12,17 @@ func TestMetadataConversions_toBlock_Only(t *testing.T) {
 	toBlock := uint64(123567890)
 	hash := common.BigToHash(new(big.Int).SetUint64(toBlock))
 	extractBlock := NewCertificateMetadataFromHash(hash)
-	require.Equal(t, toBlock, extractBlock.ToBlock)
+	require.Equal(t, toBlock, extractBlock.FromBlock)
 }
 
 func TestMetadataConversions(t *testing.T) {
 	fromBlock := uint64(123567890)
-	toBlock := uint64(123567890)
-	createdAt := uint64(0)
-	meta := NewCertificateMetadata(fromBlock, toBlock, createdAt)
+	offset := uint32(1000)
+	createdAt := uint32(0)
+	meta := NewCertificateMetadata(fromBlock, offset, createdAt)
 	c := meta.ToHash()
 	extractBlock := NewCertificateMetadataFromHash(c)
 	require.Equal(t, fromBlock, extractBlock.FromBlock)
-	require.Equal(t, toBlock, extractBlock.ToBlock)
+	require.Equal(t, offset, extractBlock.Offset)
 	require.Equal(t, createdAt, extractBlock.CreatedAt)
 }

--- a/aggsender/types/types_test.go
+++ b/aggsender/types/types_test.go
@@ -11,8 +11,8 @@ import (
 func TestMetadataConversions_toBlock_Only(t *testing.T) {
 	toBlock := uint64(123567890)
 	hash := common.BigToHash(new(big.Int).SetUint64(toBlock))
-	extractBlock := NewCertificateMetadataFromHash(hash)
-	require.Equal(t, toBlock, extractBlock.FromBlock)
+	meta := NewCertificateMetadataFromHash(hash)
+	require.Equal(t, toBlock, meta.ToBlock)
 }
 
 func TestMetadataConversions(t *testing.T) {


### PR DESCRIPTION
Refactoring the encoding of the values into the metadata field makes it compatible with the previously existing values, added a test for that.

Also moving tests to the types package where it belongs.
