### PR TITLE
fix: remove deprecated `aggsender` config fields

### DIFF
--- a/aggsender/aggsender_test.go
+++ b/aggsender/aggsender_test.go
@@ -34,15 +34,12 @@ const (
 var (
 	errTest = errors.New("unitest  error")
 	ler1    = common.HexToHash("0x123")
-	ler2    = common.HexToHash("0x12345")
 )
 
 func TestConfigString(t *testing.T) {
 	config := Config{
 		StoragePath:                 "/path/to/storage",
 		AggLayerURL:                 "http://agglayer.url",
-		BlockGetInterval:            types.Duration{Duration: 10 * time.Second},
-		CheckSettledInterval:        types.Duration{Duration: 20 * time.Second},
 		AggsenderPrivateKey:         types.KeystoreFileConfig{Path: "/path/to/key", Password: "password"},
 		URLRPCL2:                    "http://l2.rpc.url",
 		BlockFinality:               "latestBlock",
@@ -52,8 +49,6 @@ func TestConfigString(t *testing.T) {
 
 	expected := "StoragePath: /path/to/storage\n" +
 		"AggLayerURL: http://agglayer.url\n" +
-		"BlockGetInterval: 10s\n" +
-		"CheckSettledInterval: 20s\n" +
 		"AggsenderPrivateKeyPath: /path/to/key\n" +
 		"URLRPCL2: http://l2.rpc.url\n" +
 		"BlockFinality: latestBlock\n" +
@@ -926,10 +921,7 @@ func TestCheckIfCertificatesAreSettled(t *testing.T) {
 				log:            mockLogger,
 				storage:        mockStorage,
 				aggLayerClient: mockAggLayerClient,
-				cfg: Config{
-					BlockGetInterval:     types.Duration{Duration: time.Second},
-					CheckSettledInterval: types.Duration{Duration: time.Second},
-				},
+				cfg:            Config{},
 			}
 
 			ctx := context.TODO()
@@ -1671,10 +1663,7 @@ func TestSendCertificate_NoClaims(t *testing.T) {
 		aggLayerClient:   mockAggLayerClient,
 		l1infoTreeSyncer: mockL1InfoTreeSyncer,
 		sequencerKey:     privateKey,
-		cfg: Config{
-			BlockGetInterval:     types.Duration{Duration: time.Second},
-			CheckSettledInterval: types.Duration{Duration: time.Second},
-		},
+		cfg:              Config{},
 	}
 
 	mockStorage.On("GetCertificatesByStatus", agglayer.NonSettledStatuses).Return([]*aggsendertypes.CertificateInfo{}, nil).Once()

--- a/aggsender/config.go
+++ b/aggsender/config.go
@@ -12,10 +12,6 @@ type Config struct {
 	StoragePath string `mapstructure:"StoragePath"`
 	// AggLayerURL is the URL of the AggLayer
 	AggLayerURL string `mapstructure:"AggLayerURL"`
-	// BlockGetInterval is the interval at which the AggSender will get the blocks from L1
-	BlockGetInterval types.Duration `mapstructure:"BlockGetInterval"`
-	// CheckSettledInterval is the interval at which the AggSender will check if the blocks are settled
-	CheckSettledInterval types.Duration `mapstructure:"CheckSettledInterval"`
 	// AggsenderPrivateKey is the private key which is used to sign certificates
 	AggsenderPrivateKey types.KeystoreFileConfig `mapstructure:"AggsenderPrivateKey"`
 	// URLRPCL2 is the URL of the L2 RPC node
@@ -44,8 +40,6 @@ type Config struct {
 func (c Config) String() string {
 	return "StoragePath: " + c.StoragePath + "\n" +
 		"AggLayerURL: " + c.AggLayerURL + "\n" +
-		"BlockGetInterval: " + c.BlockGetInterval.String() + "\n" +
-		"CheckSettledInterval: " + c.CheckSettledInterval.String() + "\n" +
 		"AggsenderPrivateKeyPath: " + c.AggsenderPrivateKey.Path + "\n" +
 		"URLRPCL2: " + c.URLRPCL2 + "\n" +
 		"BlockFinality: " + c.BlockFinality + "\n" +

--- a/config/default.go
+++ b/config/default.go
@@ -331,9 +331,7 @@ GlobalExitRootManagerAddr = "{{L1Config.polygonZkEVMGlobalExitRootAddress}}"
 StoragePath = "{{PathRWData}}/aggsender.sqlite"
 AggLayerURL = "{{AggLayerURL}}"
 AggsenderPrivateKey = {Path = "{{SequencerPrivateKeyPath}}", Password = "{{SequencerPrivateKeyPassword}}"}
-BlockGetInterval = "2s"
 URLRPCL2="{{L2URL}}"
-CheckSettledInterval = "2s"
 BlockFinality = "LatestBlock"
 EpochNotificationPercentage = 50
 SaveCertificatesToFilesPath = ""

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -55,8 +55,6 @@ Outputs = ["stderr"]
         SettlementBackend = "agglayer"
        
 [AggSender]
-CertificateSendInterval = "1m"
-CheckSettledInterval = "5s"
 SaveCertificatesToFilesPath = "{{.zkevm_path_rw_data}}/"
 
 


### PR DESCRIPTION
## Description

This PR removes deprecated config fields from the `aggsender`'s config:
- `BlockGetInterval`
- `CheckSettledInterval`
