### PR TITLE
fix: Aggsender high cpu usage

### DIFF
--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -147,7 +147,7 @@ func (b *BlockNotifierPolling) step(ctx context.Context,
 		BlockNumber:       currentBlock.Number.Uint64(),
 		BlockFinalityType: b.config.BlockFinalityType,
 	}
-	if previousState.lastBlockSeen-currentBlock.Number.Uint64() > 1 {
+	if previousState.lastBlockSeen > currentBlock.Number.Uint64() {
 		b.logger.Warnf("Block number decreased [finality:%s]: %d -> %d",
 			b.config.BlockFinalityType, previousState.lastBlockSeen, currentBlock.Number.Uint64())
 		// It start from scratch because something fails in calculation of block period
@@ -155,7 +155,7 @@ func (b *BlockNotifierPolling) step(ctx context.Context,
 		return b.nextBlockRequestDelay(nil, nil), newState, eventToEmit
 	}
 
-	if currentBlock.Number.Uint64()-previousState.lastBlockSeen > 1 {
+	if currentBlock.Number.Uint64()-previousState.lastBlockSeen != 1 {
 		b.logger.Warnf("Missed block(s) [finality:%s]: %d -> %d",
 			b.config.BlockFinalityType, previousState.lastBlockSeen, currentBlock.Number.Uint64())
 		// It start from scratch because something fails in calculation of block period

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -188,7 +188,7 @@ func (b *BlockNotifierPolling) nextBlockRequestDelay(status *blockNotifierPollin
 	now := timeNowFunc()
 	expectedTimeNextBlock := status.lastBlockTime.Add(*status.previousBlockTime)
 	distanceToNextBlock := expectedTimeNextBlock.Sub(now)
-	interval := distanceToNextBlock * time.Duration(percentForNextInterval) / 100 //nolint:mnd //  percent period for reach the next block
+	interval := distanceToNextBlock * percentForNextBlock / 100 //nolint:mnd //  percent period for reach the next block
 	return max(minBlockInterval, min(maxBlockInterval, interval))
 }
 

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	timeNowFunc = time.Now
+	timeNowFunc            = time.Now
+	percentForNextInterval = 80
 )
 
 const (
@@ -186,7 +187,7 @@ func (b *BlockNotifierPolling) nextBlockRequestDelay(status *blockNotifierPollin
 	now := timeNowFunc()
 	expectedTimeNextBlock := status.lastBlockTime.Add(*status.previousBlockTime)
 	distanceToNextBlock := expectedTimeNextBlock.Sub(now)
-	interval := distanceToNextBlock * 4 / 5 //nolint:mnd //  80% of for reach the next block
+	interval := distanceToNextBlock * time.Duration(percentForNextInterval) / 100 //nolint:mnd //  80% of for reach the next block
 	return max(minBlockInterval, min(maxBlockInterval, interval))
 }
 

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	timeNowFunc         = time.Now
-	percentForNextBlock = 80
+	timeNowFunc = time.Now
 )
 
 const (
@@ -22,6 +21,8 @@ const (
 	minBlockInterval = time.Second
 	// maxBlockInterval is the maximum interval at which the AggSender will check for new blocks
 	maxBlockInterval = time.Minute
+	// Percentage period of reach the next block
+	percentForNextBlock = 80
 )
 
 type ConfigBlockNotifierPolling struct {
@@ -187,7 +188,7 @@ func (b *BlockNotifierPolling) nextBlockRequestDelay(status *blockNotifierPollin
 	now := timeNowFunc()
 	expectedTimeNextBlock := status.lastBlockTime.Add(*status.previousBlockTime)
 	distanceToNextBlock := expectedTimeNextBlock.Sub(now)
-	interval := distanceToNextBlock * time.Duration(percentForNextInterval) / 100 //nolint:mnd //  percent periodfor reach the next block
+	interval := distanceToNextBlock * time.Duration(percentForNextInterval) / 100 //nolint:mnd //  percent period for reach the next block
 	return max(minBlockInterval, min(maxBlockInterval, interval))
 }
 

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	timeNowFunc            = time.Now
-	percentForNextInterval = 80
+	timeNowFunc         = time.Now
+	percentForNextBlock = 80
 )
 
 const (
@@ -187,7 +187,7 @@ func (b *BlockNotifierPolling) nextBlockRequestDelay(status *blockNotifierPollin
 	now := timeNowFunc()
 	expectedTimeNextBlock := status.lastBlockTime.Add(*status.previousBlockTime)
 	distanceToNextBlock := expectedTimeNextBlock.Sub(now)
-	interval := distanceToNextBlock * time.Duration(percentForNextInterval) / 100 //nolint:mnd //  80% of for reach the next block
+	interval := distanceToNextBlock * time.Duration(percentForNextInterval) / 100 //nolint:mnd //  percent periodfor reach the next block
 	return max(minBlockInterval, min(maxBlockInterval, interval))
 }
 

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -147,7 +147,7 @@ func (b *BlockNotifierPolling) step(ctx context.Context,
 		BlockNumber:       currentBlock.Number.Uint64(),
 		BlockFinalityType: b.config.BlockFinalityType,
 	}
-	if currentBlock.Number.Uint64()-previousState.lastBlockSeen < 0 {
+	if previousState.lastBlockSeen-currentBlock.Number.Uint64() > 1 {
 		b.logger.Warnf("Block number decreased [finality:%s]: %d -> %d",
 			b.config.BlockFinalityType, previousState.lastBlockSeen, currentBlock.Number.Uint64())
 		// It start from scratch because something fails in calculation of block period

--- a/aggsender/block_notifier_polling.go
+++ b/aggsender/block_notifier_polling.go
@@ -164,7 +164,7 @@ func (b *BlockNotifierPolling) step(ctx context.Context,
 
 func (b *BlockNotifierPolling) nextBlockRequestDelay(status *blockNotifierPollingInternalStatus,
 	err error) time.Duration {
-	if b.config.CheckNewBlockInterval == AutomaticBlockInterval {
+	if b.config.CheckNewBlockInterval != AutomaticBlockInterval {
 		return b.config.CheckNewBlockInterval
 	}
 	// Initial stages wait the minimum interval to increas accuracy

--- a/aggsender/block_notifier_polling_test.go
+++ b/aggsender/block_notifier_polling_test.go
@@ -196,13 +196,13 @@ func newBlockNotifierPollingTestData(t *testing.T, config *ConfigBlockNotifierPo
 			CheckNewBlockInterval: 0,
 		}
 	}
-	EthClientMock := mocks.NewEthClient(t)
+	ethClientMock := mocks.NewEthClient(t)
 	logger := log.WithFields("test", "BlockNotifierPolling")
-	sut, err := NewBlockNotifierPolling(EthClientMock, *config, logger, nil)
+	sut, err := NewBlockNotifierPolling(ethClientMock, *config, logger, nil)
 	require.NoError(t, err)
 	return blockNotifierPollingTestData{
 		sut:           sut,
-		ethClientMock: EthClientMock,
+		ethClientMock: ethClientMock,
 		ctx:           context.TODO(),
 	}
 }

--- a/aggsender/block_notifier_polling_test.go
+++ b/aggsender/block_notifier_polling_test.go
@@ -193,7 +193,7 @@ func newBlockNotifierPollingTestData(t *testing.T, config *ConfigBlockNotifierPo
 	if config == nil {
 		config = &ConfigBlockNotifierPolling{
 			BlockFinalityType:     etherman.LatestBlock,
-			CheckNewBlockInterval: time.Second,
+			CheckNewBlockInterval: 0,
 		}
 	}
 	EthClientMock := mocks.NewEthClient(t)

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,5 +1,5 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.12
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.21
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta8
   cdk_node_image: cdk
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,5 +1,5 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.21
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta8
   cdk_node_image: cdk
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm


### PR DESCRIPTION
## Description

- Aggsender is using about 200% of CPU (version: `v0.5.0-beta8`)
- Add a warning if decrease blockNumber (from L1 provider)