### PR TITLE
chore: minor `aggoracle` cleanups

### DIFF
--- a/aggoracle/chaingersender/evm.go
+++ b/aggoracle/chaingersender/evm.go
@@ -82,16 +82,16 @@ func NewEVMChainGERSender(
 	}, nil
 }
 
-func (c *EVMChainGERSender) IsGERAlreadyInjected(ger common.Hash) (bool, error) {
+func (c *EVMChainGERSender) IsGERInjected(ger common.Hash) (bool, error) {
 	timestamp, err := c.gerContract.GlobalExitRootMap(&bind.CallOpts{Pending: false}, ger)
 	if err != nil {
 		return false, fmt.Errorf("error calling gerContract.GlobalExitRootMap: %w", err)
 	}
 
-	return timestamp.Cmp(big.NewInt(0)) != 0, nil
+	return timestamp.Cmp(common.Big0) != 0, nil
 }
 
-func (c *EVMChainGERSender) UpdateGERWaitUntilMined(ctx context.Context, ger common.Hash) error {
+func (c *EVMChainGERSender) InjectGER(ctx context.Context, ger common.Hash) error {
 	ticker := time.NewTicker(c.waitPeriodMonitorTx)
 	defer ticker.Stop()
 

--- a/aggoracle/e2e_test.go
+++ b/aggoracle/e2e_test.go
@@ -36,7 +36,7 @@ func runTest(
 		time.Sleep(time.Millisecond * 150)
 		expectedGER, err := gerL1Contract.GetLastGlobalExitRoot(&bind.CallOpts{Pending: false})
 		require.NoError(t, err)
-		isInjected, err := sender.IsGERAlreadyInjected(expectedGER)
+		isInjected, err := sender.IsGERInjected(expectedGER)
 		require.NoError(t, err)
 		require.True(t, isInjected, fmt.Sprintf("iteration %d, GER: %s", i, common.Bytes2Hex(expectedGER[:])))
 	}

--- a/aggoracle/oracle.go
+++ b/aggoracle/oracle.go
@@ -20,8 +20,8 @@ type L1InfoTreer interface {
 }
 
 type ChainSender interface {
-	IsGERAlreadyInjected(ger common.Hash) (bool, error)
-	UpdateGERWaitUntilMined(ctx context.Context, ger common.Hash) error
+	IsGERInjected(ger common.Hash) (bool, error)
+	InjectGER(ctx context.Context, ger common.Hash) error
 }
 
 type AggOracle struct {
@@ -85,7 +85,7 @@ func (a *AggOracle) processLatestGER(ctx context.Context, blockNumToFetch *uint6
 	// Update the block number for the next iteration
 	*blockNumToFetch = blockNum
 
-	alreadyInjected, err := a.chainSender.IsGERAlreadyInjected(gerToInject)
+	alreadyInjected, err := a.chainSender.IsGERInjected(gerToInject)
 	if err != nil {
 		return fmt.Errorf("error checking if GER is already injected: %w", err)
 	}
@@ -95,7 +95,7 @@ func (a *AggOracle) processLatestGER(ctx context.Context, blockNumToFetch *uint6
 	}
 
 	a.logger.Infof("injecting new GER: %s", gerToInject.Hex())
-	if err := a.chainSender.UpdateGERWaitUntilMined(ctx, gerToInject); err != nil {
+	if err := a.chainSender.InjectGER(ctx, gerToInject); err != nil {
 		return fmt.Errorf("error injecting GER %s: %w", gerToInject.Hex(), err)
 	}
 

--- a/aggoracle/oracle.go
+++ b/aggoracle/oracle.go
@@ -3,6 +3,7 @@ package aggoracle
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -56,61 +57,69 @@ func New(
 }
 
 func (a *AggOracle) Start(ctx context.Context) {
-	var (
-		blockNumToFetch uint64
-		gerToInject     common.Hash
-		err             error
-	)
-
 	ticker := time.NewTicker(a.waitPeriodNextGER)
 	defer ticker.Stop()
+
+	var blockNumToFetch uint64
 
 	for {
 		select {
 		case <-ticker.C:
-			blockNumToFetch, gerToInject, err = a.getLastFinalisedGER(ctx, blockNumToFetch)
-			if err != nil {
-				switch {
-				case errors.Is(err, l1infotreesync.ErrBlockNotProcessed):
-					a.logger.Debugf("syncer is not ready for the block %d", blockNumToFetch)
-
-				case errors.Is(err, db.ErrNotFound):
-					blockNumToFetch = 0
-					a.logger.Debugf("syncer has not found any GER until block %d", blockNumToFetch)
-
-				default:
-					a.logger.Error("error calling getLastFinalisedGER: ", err)
-				}
-
-				continue
+			if err := a.processLatestGER(ctx, &blockNumToFetch); err != nil {
+				a.handleGERProcessingError(err, blockNumToFetch)
 			}
-
-			if alreadyInjected, err := a.chainSender.IsGERAlreadyInjected(gerToInject); err != nil {
-				a.logger.Error("error calling isGERAlreadyInjected: ", err)
-				continue
-			} else if alreadyInjected {
-				a.logger.Debugf("GER %s already injected", gerToInject.Hex())
-				continue
-			}
-
-			a.logger.Infof("injecting new GER: %s", gerToInject.Hex())
-			if err := a.chainSender.UpdateGERWaitUntilMined(ctx, gerToInject); err != nil {
-				a.logger.Errorf("error calling updateGERWaitUntilMined, when trying to inject GER %s: %v", gerToInject.Hex(), err)
-				continue
-			}
-
-			a.logger.Infof("GER %s injected", gerToInject.Hex())
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// getLastFinalisedGER tries to return a finalised GER:
+// processLatestGER fetches the latest finalized GER, checks if it is already injected and injects it if not
+func (a *AggOracle) processLatestGER(ctx context.Context, blockNumToFetch *uint64) error {
+	// Fetch the latest GER
+	blockNum, gerToInject, err := a.getLastFinalizedGER(ctx, *blockNumToFetch)
+	if err != nil {
+		return err
+	}
+
+	// Update the block number for the next iteration
+	*blockNumToFetch = blockNum
+
+	alreadyInjected, err := a.chainSender.IsGERAlreadyInjected(gerToInject)
+	if err != nil {
+		return fmt.Errorf("error checking if GER is already injected: %w", err)
+	}
+	if alreadyInjected {
+		a.logger.Debugf("GER %s already injected", gerToInject.Hex())
+		return nil
+	}
+
+	a.logger.Infof("injecting new GER: %s", gerToInject.Hex())
+	if err := a.chainSender.UpdateGERWaitUntilMined(ctx, gerToInject); err != nil {
+		return fmt.Errorf("error injecting GER %s: %w", gerToInject.Hex(), err)
+	}
+
+	a.logger.Infof("GER %s is injected successfully", gerToInject.Hex())
+	return nil
+}
+
+// handleGERProcessingError handles global exit root processing error
+func (a *AggOracle) handleGERProcessingError(err error, blockNumToFetch uint64) {
+	switch {
+	case errors.Is(err, l1infotreesync.ErrBlockNotProcessed):
+		a.logger.Debugf("syncer is not ready for the block %d", blockNumToFetch)
+	case errors.Is(err, db.ErrNotFound):
+		a.logger.Debugf("syncer has not found any GER until block %d", blockNumToFetch)
+	default:
+		a.logger.Error("unexpected error processing GER: ", err)
+	}
+}
+
+// getLastFinalizedGER tries to return a finalised GER:
 // If targetBlockNum != 0: it will try to fetch it until the given block
 // Else it will ask the L1 client for the latest finalised block and use that.
 // If it fails to get the GER from the syncer, it will return the block number that used to query
-func (a *AggOracle) getLastFinalisedGER(ctx context.Context, targetBlockNum uint64) (uint64, common.Hash, error) {
+func (a *AggOracle) getLastFinalizedGER(ctx context.Context, targetBlockNum uint64) (uint64, common.Hash, error) {
 	if targetBlockNum == 0 {
 		header, err := a.l1Client.HeaderByNumber(ctx, a.blockFinality)
 		if err != nil {

--- a/claimsponsor/e2e_test.go
+++ b/claimsponsor/e2e_test.go
@@ -56,7 +56,7 @@ func TestE2EL1toEVML2(t *testing.T) {
 		time.Sleep(time.Millisecond * 300)
 		expectedGER, err := env.GERL1Contract.GetLastGlobalExitRoot(&bind.CallOpts{Pending: false})
 		require.NoError(t, err)
-		isInjected, err := env.AggOracleSender.IsGERAlreadyInjected(expectedGER)
+		isInjected, err := env.AggOracleSender.IsGERInjected(expectedGER)
 		require.NoError(t, err)
 		require.True(t, isInjected, fmt.Sprintf("iteration %d, GER: %s", i, common.Bytes2Hex(expectedGER[:])))
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -343,7 +343,6 @@ func createAggoracle(
 		sender, err = chaingersender.NewEVMChainGERSender(
 			logger,
 			cfg.AggOracle.EVMSender.GlobalExitRootL2Addr,
-			cfg.AggOracle.EVMSender.SenderAddr,
 			l2Client,
 			ethTxManager,
 			cfg.AggOracle.EVMSender.GasOffset,

--- a/config/default.go
+++ b/config/default.go
@@ -228,7 +228,6 @@ WaitPeriodNextGER="100ms"
 		ChainIDL2=1337
 		GasOffset=0
 		WaitPeriodMonitorTx="100ms"
-		SenderAddr="0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
 		[AggOracle.EVMSender.EthTxManager]
 				FrequencyToMonitorTxs = "1s"
 				WaitTxToBeMined = "2s"

--- a/lastgersync/e2e_test.go
+++ b/lastgersync/e2e_test.go
@@ -44,7 +44,7 @@ func TestE2E(t *testing.T) {
 		time.Sleep(time.Millisecond * 150)
 		expectedGER, err := env.GERL1Contract.GetLastGlobalExitRoot(&bind.CallOpts{Pending: false})
 		require.NoError(t, err)
-		isInjected, err := env.AggOracleSender.IsGERAlreadyInjected(expectedGER)
+		isInjected, err := env.AggOracleSender.IsGERInjected(expectedGER)
 		require.NoError(t, err)
 		require.True(t, isInjected, fmt.Sprintf("iteration %d, GER: %s", i, common.Bytes2Hex(expectedGER[:])))
 

--- a/test/helpers/reorg.go
+++ b/test/helpers/reorg.go
@@ -11,7 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// commitBlocks commits the specified number of blocks with the given client and waits for the specified duration after each block
+// commitBlocks commits the specified number of blocks with the given client
+// and waits for the specified duration after each block
 func CommitBlocks(t *testing.T, client *simulated.Backend, numBlocks int, waitDuration time.Duration) {
 	t.Helper()
 


### PR DESCRIPTION
## Description

A couple of minor changes and cleanups in the aggoracle here and there:
- remove of the `sender` address field, since it is unused
- proper disposal of `ticker` in the `oracle.go`
- refactor the `Aggoracle` logic into smaller functions
- renames 
