### PR TITLE
feat: optimize the request RPC timeout config

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -168,7 +168,7 @@ func New(
 		aggLayerClient:          aggLayerClient,
 		sequencerPrivateKey:     sequencerPrivateKey,
 		witnessRetrievalChan:    make(chan state.DBBatch),
-		rpcClient:               rpc.NewBatchEndpoints(cfg.RPCURL),
+		rpcClient:               rpc.NewBatchEndpoints(cfg.RPCURL, cfg.RPCTimeout.Duration),
 	}
 
 	if a.ctx == nil {

--- a/aggregator/config.go
+++ b/aggregator/config.go
@@ -111,6 +111,9 @@ type Config struct {
 	// RPCURL is the URL of the RPC server
 	RPCURL string `mapstructure:"RPCURL"`
 
+	// RPCTimeout is the timeout for the L2 RPC calls
+	RPCTimeout types.Duration `mapstructure:"RPCTimeout"`
+
 	// WitnessURL is the URL of the witness server
 	WitnessURL string `mapstructure:"WitnessURL"`
 

--- a/config/default.go
+++ b/config/default.go
@@ -91,6 +91,7 @@ MaxPendingTx = 1
 MaxBatchesForL1 = 300
 BlockFinality = "FinalizedBlock"
 RPCURL = "{{L2URL}}"
+RPCTimeout = "2m"
 GetBatchWaitInterval = "10s"
 	[SequenceSender.EthTxManager]
 		FrequencyToMonitorTxs = "1s"
@@ -131,6 +132,7 @@ CleanupLockedProofsInterval = "2m"
 GeneratingProofCleanupThreshold = "10m"
 GasOffset = 0
 RPCURL = "{{L2URL}}"
+RPCTimeout = "2m"
 WitnessURL = "{{WitnessURL}}"
 UseFullWitness = false
 SettlementBackend = "l1"

--- a/rpc/batch.go
+++ b/rpc/batch.go
@@ -51,7 +51,9 @@ func (b *BatchEndpoints) GetBatch(batchNumber uint64) (*types.RPCBatch, error) {
 
 	log.Infof("Getting batch %d from RPC", batchNumber)
 
-	response, err := rpc.JSONRPCCall(b.url, "zkevm_getBatchByNumber", batchNumber)
+	ctx, cancel := context.WithTimeout(context.Background(), b.readTimeout)
+	defer cancel()
+	response, err := rpc.JSONRPCCallWithContext(ctx, b.url, "zkevm_getBatchByNumber", batchNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/batch.go
+++ b/rpc/batch.go
@@ -1,10 +1,12 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/cdk-rpc/rpc"
 	"github.com/0xPolygon/cdk/log"
@@ -21,11 +23,15 @@ var (
 const busyResponse = "busy"
 
 type BatchEndpoints struct {
-	url string
+	url         string
+	readTimeout time.Duration
 }
 
-func NewBatchEndpoints(url string) *BatchEndpoints {
-	return &BatchEndpoints{url: url}
+func NewBatchEndpoints(url string, readTimeout time.Duration) *BatchEndpoints {
+	return &BatchEndpoints{
+		url:         url,
+		readTimeout: readTimeout,
+	}
 }
 
 func (b *BatchEndpoints) GetBatch(batchNumber uint64) (*types.RPCBatch, error) {
@@ -92,7 +98,9 @@ func (b *BatchEndpoints) GetL2BlockTimestamp(blockHash string) (uint64, error) {
 
 	log.Infof("Getting l2 block timestamp from RPC. Block hash: %s", blockHash)
 
-	response, err := rpc.JSONRPCCall(b.url, "eth_getBlockByHash", blockHash, false)
+	ctx, cancel := context.WithTimeout(context.Background(), b.readTimeout)
+	defer cancel()
+	response, err := rpc.JSONRPCCallWithContext(ctx, b.url, "eth_getBlockByHash", blockHash, false)
 	if err != nil {
 		return 0, err
 	}
@@ -126,7 +134,9 @@ func (b *BatchEndpoints) GetWitness(batchNumber uint64, fullWitness bool) ([]byt
 
 	log.Infof("Requesting witness for batch %d of type %s", batchNumber, witnessType)
 
-	response, err = rpc.JSONRPCCall(b.url, "zkevm_getBatchWitness", batchNumber, witnessType)
+	ctx, cancel := context.WithTimeout(context.Background(), b.readTimeout)
+	defer cancel()
+	response, err = rpc.JSONRPCCallWithContext(ctx, b.url, "zkevm_getBatchWitness", batchNumber, witnessType)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/batch_test.go
+++ b/rpc/batch_test.go
@@ -103,7 +103,7 @@ func Test_getBatchFromRPC(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			rcpBatchClient := NewBatchEndpoints(srv.URL)
+			rcpBatchClient := NewBatchEndpoints(srv.URL, 0)
 			rpcBatch, err := rcpBatchClient.GetBatch(tt.batch)
 			if rpcBatch != nil {
 				copiedrpcBatch := rpcBatch.DeepCopy()
@@ -187,7 +187,7 @@ func Test_getBatchWitnessRPC(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			rcpBatchClient := NewBatchEndpoints(srv.URL)
+			rcpBatchClient := NewBatchEndpoints(srv.URL, 0)
 			witness, err := rcpBatchClient.GetWitness(tt.batch, false)
 			if tt.expectErr != nil {
 				require.Equal(t, tt.expectErr.Error(), err.Error())
@@ -252,7 +252,7 @@ func Test_getGetL2BlockTimestamp(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			rcpBatchClient := NewBatchEndpoints(srv.URL)
+			rcpBatchClient := NewBatchEndpoints(srv.URL, 0)
 			timestamp, err := rcpBatchClient.GetL2BlockTimestamp(string(tt.blockHash))
 			if tt.expectErr != nil {
 				require.Equal(t, tt.expectErr.Error(), err.Error())

--- a/sequencesender/config.go
+++ b/sequencesender/config.go
@@ -68,6 +68,9 @@ type Config struct {
 	// RPCURL is the URL of the RPC server
 	RPCURL string `mapstructure:"RPCURL"`
 
+	// RPCTimeout is the timeout for the L2 RPC calls
+	RPCTimeout types.Duration `mapstructure:"RPCTimeout"`
+
 	// GetBatchWaitInterval is the time to wait to query for a new batch when there are no more batches available
 	GetBatchWaitInterval types.Duration `mapstructure:"GetBatchWaitInterval"`
 }

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -98,7 +98,7 @@ func New(cfg Config, logger *log.Logger,
 		sequenceData:    make(map[uint64]*sequenceData),
 		validStream:     false,
 		TxBuilder:       txBuilder,
-		rpcClient:       rpc.NewBatchEndpoints(cfg.RPCURL),
+		rpcClient:       rpc.NewBatchEndpoints(cfg.RPCURL, cfg.RPCTimeout.Duration),
 	}
 
 	logger.Infof("TxBuilder configuration: %s", txBuilder.String())


### PR DESCRIPTION
## Description

When requesting a witness, the process can sometimes hang for an extended period. Adding a timeout helps prevent excessive delays.
