### PR TITLE
feat: more logs for `l1infotreesyncer`

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.24
+        ref: v0.2.25
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,24 +7,44 @@ on:
 
 
 jobs:
+  build-cdk-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: 1.22.x
+
+    - name: Build cdk docker image
+      run: make build-docker
+    
+    - name: Save cdk image to archive
+      run: docker save --output /tmp/cdk.tar cdk
+    
+    - name: Upload archive
+      uses: actions/upload-artifact@v4
+      with:
+        name: cdk
+        path: /tmp/cdk.tar
+
   test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-cdk-image
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ 1.22.x ]
-        goarch: [ "amd64" ]
         e2e-group:
           - "fork9-validium"
           - "fork11-rollup"
           - "fork12-validium"
           - "fork12-rollup"
-    runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    - uses: actions/checkout@v4
+    
+    - name: Checkout kurtosis-cdk repository
       uses: actions/checkout@v4
-
-    - name: Install Go
-      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
       env:
@@ -32,26 +52,17 @@ jobs:
 
     - name: Build Docker
       run: make build-docker
- 
-      # this is better to get the action in
-    - name: Install kurtosis
-      shell: bash
-      run: |
-        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-        sudo apt update
-        sudo apt install kurtosis-cli=1.4.1
-        kurtosis version
-
-    - name: Disable kurtosis analytics
-      shell: bash
-      run: kurtosis analytics disable
-
-    - name: Install yq
-      shell: bash
-      run: |
-        pip3 install yq
-        yq --version
-
+    
+    - name: Checkout kurtosis-cdk
+      uses: actions/checkout@v4
+      with:
+        repository: 0xPolygon/kurtosis-cdk
+        path: kurtosis-cdk
+        ref: v0.2.24
+    
+    - name: Install Kurtosis CDK tools
+      uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
+    
     - name: Install polycli
       run: |
         POLYCLI_VERSION="${{ vars.POLYCLI_VERSION }}"
@@ -62,25 +73,27 @@ jobs:
         sudo chmod +x /usr/local/bin/polycli
         /usr/local/bin/polycli version
 
-    - name: Install foundry
-      uses: foundry-rs/foundry-toolchain@v1
-
-    - name: checkout kurtosis-cdk
-      uses: actions/checkout@v4
-      with:
-        repository: 0xPolygon/kurtosis-cdk
-        path: "kurtosis-cdk"
-        ref: "v0.2.19"
-
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0
+    
+    - name: Download cdk archive
+      uses: actions/download-artifact@v4
+      with:
+        name: cdk
+        path: /tmp
+    
+    - name: Load cdk image
+      run: |
+        docker load --input /tmp/cdk.tar
+        docker image ls -a
 
-    - name: Test
+    - name: Run e2e tests
       run: make test-e2e-${{ matrix.e2e-group }}
       working-directory: test
       env:
         KURTOSIS_FOLDER: ${{ github.workspace }}/kurtosis-cdk
         BATS_LIB_PATH: /usr/lib/
+        agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
     
     - name: Dump enclave logs
       if: failure()

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -45,10 +45,6 @@ jobs:
     
     - name: Checkout kurtosis-cdk repository
       uses: actions/checkout@v4
-      with:
-        go-version: ${{ matrix.go-version }}
-      env:
-        GOARCH: ${{ matrix.goarch }}
 
     - name: Build Docker
       run: make build-docker

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,58 +7,51 @@ on:
 
 
 jobs:
-  build-cdk-image:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: 1.22.x
-
-    - name: Build cdk docker image
-      run: make build-docker
-    
-    - name: Save cdk image to archive
-      run: docker save --output /tmp/cdk.tar cdk
-    
-    - name: Upload archive
-      uses: actions/upload-artifact@v4
-      with:
-        name: cdk
-        path: /tmp/cdk.tar
-
   test-e2e:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: build-cdk-image
     strategy:
       fail-fast: false
       matrix:
+        go-version: [ 1.22.x ]
+        goarch: [ "amd64" ]
         e2e-group:
           - "fork9-validium"
           - "fork11-rollup"
           - "fork12-validium"
           - "fork12-rollup"
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Checkout kurtosis-cdk repository
+    - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+      env:
+        GOARCH: ${{ matrix.goarch }}
 
     - name: Build Docker
       run: make build-docker
-    
-    - name: Checkout kurtosis-cdk
-      uses: actions/checkout@v4
-      with:
-        repository: 0xPolygon/kurtosis-cdk
-        path: kurtosis-cdk
-        ref: v0.2.25
-    
-    - name: Install Kurtosis CDK tools
-      uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
-    
+ 
+      # this is better to get the action in
+    - name: Install kurtosis
+      shell: bash
+      run: |
+        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        sudo apt update
+        sudo apt install kurtosis-cli=1.4.1
+        kurtosis version
+
+    - name: Disable kurtosis analytics
+      shell: bash
+      run: kurtosis analytics disable
+
+    - name: Install yq
+      shell: bash
+      run: |
+        pip3 install yq
+        yq --version
+
     - name: Install polycli
       run: |
         POLYCLI_VERSION="${{ vars.POLYCLI_VERSION }}"
@@ -69,27 +62,25 @@ jobs:
         sudo chmod +x /usr/local/bin/polycli
         /usr/local/bin/polycli version
 
+    - name: Install foundry
+      uses: foundry-rs/foundry-toolchain@v1
+
+    - name: checkout kurtosis-cdk
+      uses: actions/checkout@v4
+      with:
+        repository: 0xPolygon/kurtosis-cdk
+        path: kurtosis-cdk
+        ref: v0.2.25
+
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0
-    
-    - name: Download cdk archive
-      uses: actions/download-artifact@v4
-      with:
-        name: cdk
-        path: /tmp
-    
-    - name: Load cdk image
-      run: |
-        docker load --input /tmp/cdk.tar
-        docker image ls -a
 
-    - name: Run e2e tests
+    - name: Test
       run: make test-e2e-${{ matrix.e2e-group }}
       working-directory: test
       env:
         KURTOSIS_FOLDER: ${{ github.workspace }}/kurtosis-cdk
         BATS_LIB_PATH: /usr/lib/
-        agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
     
     - name: Dump enclave logs
       if: failure()

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -23,7 +23,7 @@ func TestBridgeEventE2E(t *testing.T) {
 	dbPathReorg := path.Join(t.TempDir(), "file::memory:?cache=shared")
 
 	client, setup := helpers.SimulatedBackend(t, nil, 0)
-	rd, err := reorgdetector.New(client.Client(), reorgdetector.Config{DBPath: dbPathReorg})
+	rd, err := reorgdetector.New(client.Client(), reorgdetector.Config{DBPath: dbPathReorg}, reorgdetector.L1)
 	require.NoError(t, err)
 
 	go rd.Start(ctx) //nolint:errcheck

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -500,8 +500,9 @@ func newState(c *config.Config, l2ChainID uint64, sqlDB *pgxpool.Pool) *state.St
 func newReorgDetector(
 	cfg *reorgdetector.Config,
 	client *ethclient.Client,
+	network reorgdetector.Network,
 ) *reorgdetector.ReorgDetector {
-	rd, err := reorgdetector.New(client, *cfg)
+	rd, err := reorgdetector.New(client, *cfg, network)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -600,7 +601,7 @@ func runReorgDetectorL1IfNeeded(
 		components) {
 		return nil, nil
 	}
-	rd := newReorgDetector(cfg, l1Client)
+	rd := newReorgDetector(cfg, l1Client, reorgdetector.L1)
 
 	errChan := make(chan error)
 	go func() {
@@ -622,7 +623,7 @@ func runReorgDetectorL2IfNeeded(
 	if !isNeeded([]string{cdkcommon.AGGORACLE, cdkcommon.RPC, cdkcommon.AGGSENDER}, components) {
 		return nil, nil
 	}
-	rd := newReorgDetector(cfg, l2Client)
+	rd := newReorgDetector(cfg, l2Client, reorgdetector.L2)
 
 	errChan := make(chan error)
 	go func() {

--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -160,7 +160,7 @@ func TestWithReorgs(t *testing.T) {
 
 	client, auth, gerAddr, verifyAddr, gerSc, verifySC := newSimulatedClient(t)
 
-	rd, err := reorgdetector.New(client.Client(), reorgdetector.Config{DBPath: dbPathReorg, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 30)})
+	rd, err := reorgdetector.New(client.Client(), reorgdetector.Config{DBPath: dbPathReorg, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 30)}, reorgdetector.L1)
 	require.NoError(t, err)
 	require.NoError(t, rd.Start(ctx))
 
@@ -278,7 +278,7 @@ func TestStressAndReorgs(t *testing.T) {
 
 	client, auth, gerAddr, verifyAddr, gerSc, verifySC := newSimulatedClient(t)
 
-	rd, err := reorgdetector.New(client.Client(), reorgdetector.Config{DBPath: dbPathReorg, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)})
+	rd, err := reorgdetector.New(client.Client(), reorgdetector.Config{DBPath: dbPathReorg, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)}, reorgdetector.L1)
 	require.NoError(t, err)
 	require.NoError(t, rd.Start(ctx))
 

--- a/l1infotreesync/migrations/l1infotreesync0003.sql
+++ b/l1infotreesync/migrations/l1infotreesync0003.sql
@@ -1,0 +1,5 @@
+-- +migrate Down
+ALTER TABLE block DROP COLUMN hash;
+
+-- +migrate Up
+ALTER TABLE block ADD COLUMN hash VARCHAR;

--- a/l1infotreesync/migrations/migrations.go
+++ b/l1infotreesync/migrations/migrations.go
@@ -19,6 +19,9 @@ var mig001 string
 //go:embed l1infotreesync0002.sql
 var mig002 string
 
+//go:embed l1infotreesync0003.sql
+var mig003 string
+
 func RunMigrations(dbPath string) error {
 	migrations := []types.Migration{
 		{
@@ -28,6 +31,10 @@ func RunMigrations(dbPath string) error {
 		{
 			ID:  "l1infotreesync0002",
 			SQL: mig002,
+		},
+		{
+			ID:  "l1infotreesync0003",
+			SQL: mig003,
 		},
 	}
 	for _, tm := range treeMigrations.Migrations {

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -294,7 +294,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 		}
 	}()
 
-	if _, err := tx.Exec(`INSERT INTO block (num) VALUES ($1)`, block.Num); err != nil {
+	if _, err := tx.Exec(`INSERT INTO block (num, hash) VALUES ($1, $2)`, block.Num, block.Hash.String()); err != nil {
 		return fmt.Errorf("insert Block. err: %w", err)
 	}
 
@@ -344,6 +344,9 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			l1InfoLeavesAdded++
 		}
 		if event.UpdateL1InfoTreeV2 != nil {
+			log.Debugf("handle UpdateL1InfoTreeV2 event. Block: %d, block hash: %s. Event root: %s. Event leaf count: %d.",
+				block.Num, block.Hash, event.UpdateL1InfoTreeV2.CurrentL1InfoRoot.String(), event.UpdateL1InfoTreeV2.LeafCount)
+
 			root, err := p.l1InfoTree.GetLastRoot(tx)
 			if err != nil {
 				return fmt.Errorf("GetLastRoot(). err: %w", err)
@@ -355,10 +358,10 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			if root.Hash != event.UpdateL1InfoTreeV2.CurrentL1InfoRoot || root.Index+1 != event.UpdateL1InfoTreeV2.LeafCount {
 				errStr := fmt.Sprintf(
 					"failed to check UpdateL1InfoTreeV2. Root: %s vs event:%s. "+
-						"Index: : %d vs event.LeafCount:%d. Happened on block %d",
-					root.Hash, common.Bytes2Hex(event.UpdateL1InfoTreeV2.CurrentL1InfoRoot[:]),
+						"Index: %d vs event.LeafCount: %d. Happened on block %d. Block hash: %s.",
+					root.Hash, event.UpdateL1InfoTreeV2.CurrentL1InfoRoot.String(),
 					root.Index, event.UpdateL1InfoTreeV2.LeafCount,
-					block.Num,
+					block.Num, block.Hash.String(),
 				)
 				log.Error(errStr)
 				p.haltedReason = errStr

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -344,7 +344,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			l1InfoLeavesAdded++
 		}
 		if event.UpdateL1InfoTreeV2 != nil {
-			log.Debugf("handle UpdateL1InfoTreeV2 event. Block: %d, block hash: %s. Event root: %s. Event leaf count: %d.",
+			log.Infof("handle UpdateL1InfoTreeV2 event. Block: %d, block hash: %s. Event root: %s. Event leaf count: %d.",
 				block.Num, block.Hash, event.UpdateL1InfoTreeV2.CurrentL1InfoRoot.String(), event.UpdateL1InfoTreeV2.LeafCount)
 
 			root, err := p.l1InfoTree.GetLastRoot(tx)

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -30,6 +30,7 @@ type processor struct {
 	rollupExitTree *tree.UpdatableTree
 	halted         bool
 	haltedReason   string
+	log            *log.Logger
 }
 
 // UpdateL1InfoTree representation of the UpdateL1InfoTree event
@@ -149,6 +150,7 @@ func newProcessor(dbPath string) (*processor, error) {
 		db:             db,
 		l1InfoTree:     tree.NewAppendOnlyTree(db, migrations.L1InfoTreePrefix),
 		rollupExitTree: tree.NewUpdatableTree(db, migrations.RollupExitTreePrefix),
+		log:            log.WithFields("processor", "l1infotreesync"),
 	}, nil
 }
 
@@ -176,7 +178,7 @@ func (p *processor) GetLatestInfoUntilBlock(ctx context.Context, blockNum uint64
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil {
-			log.Warnf("error rolling back tx: %v", err)
+			p.log.Warnf("error rolling back tx: %v", err)
 		}
 	}()
 
@@ -233,6 +235,8 @@ func (p *processor) getLastProcessedBlockWithTx(tx db.Querier) (uint64, error) {
 // Reorg triggers a purge and reset process on the processor to leaf it on a state
 // as if the last block processed was firstReorgedBlock-1
 func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
+	p.log.Infof("reorging to block %d", firstReorgedBlock)
+
 	tx, err := db.NewTx(ctx, p.db)
 	if err != nil {
 		return err
@@ -266,6 +270,9 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
+
+	p.log.Infof("reorged to block %d, %d rows affected", firstReorgedBlock, rowsAffected)
+
 	if rowsAffected > 0 {
 		p.halted = false
 		p.haltedReason = ""
@@ -278,7 +285,7 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 // and updates the last processed block (can be called without events for that purpose)
 func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	if p.halted {
-		log.Errorf("processor is halted due to: %s", p.haltedReason)
+		p.log.Errorf("processor is halted due to: %s", p.haltedReason)
 		return sync.ErrInconsistentState
 	}
 	tx, err := db.NewTx(ctx, p.db)
@@ -289,7 +296,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	defer func() {
 		if shouldRollback {
 			if errRllbck := tx.Rollback(); errRllbck != nil {
-				log.Errorf("error while rolling back tx %v", errRllbck)
+				p.log.Errorf("error while rolling back tx %v", errRllbck)
 			}
 		}
 	}()
@@ -340,11 +347,11 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 			if err != nil {
 				return fmt.Errorf("AddLeaf(%s). err: %w", info.String(), err)
 			}
-			log.Infof("inserted L1InfoTreeLeaf %s", info.String())
+			p.log.Infof("inserted L1InfoTreeLeaf %s", info.String())
 			l1InfoLeavesAdded++
 		}
 		if event.UpdateL1InfoTreeV2 != nil {
-			log.Infof("handle UpdateL1InfoTreeV2 event. Block: %d, block hash: %s. Event root: %s. Event leaf count: %d.",
+			p.log.Infof("handle UpdateL1InfoTreeV2 event. Block: %d, block hash: %s. Event root: %s. Event leaf count: %d.",
 				block.Num, block.Hash, event.UpdateL1InfoTreeV2.CurrentL1InfoRoot.String(), event.UpdateL1InfoTreeV2.LeafCount)
 
 			root, err := p.l1InfoTree.GetLastRoot(tx)
@@ -363,28 +370,28 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 					root.Index, event.UpdateL1InfoTreeV2.LeafCount,
 					block.Num, block.Hash.String(),
 				)
-				log.Error(errStr)
+				p.log.Error(errStr)
 				p.haltedReason = errStr
 				p.halted = true
 				return sync.ErrInconsistentState
 			}
 		}
 		if event.VerifyBatches != nil {
-			log.Debugf("handle VerifyBatches event %s", event.VerifyBatches.String())
+			p.log.Debugf("handle VerifyBatches event %s", event.VerifyBatches.String())
 			err = p.processVerifyBatches(tx, block.Num, event.VerifyBatches)
 			if err != nil {
 				err = fmt.Errorf("processVerifyBatches. err: %w", err)
-				log.Errorf("error processing VerifyBatches: %v", err)
+				p.log.Errorf("error processing VerifyBatches: %v", err)
 				return err
 			}
 		}
 
 		if event.InitL1InfoRootMap != nil {
-			log.Debugf("handle InitL1InfoRootMap event %s", event.InitL1InfoRootMap.String())
+			p.log.Debugf("handle InitL1InfoRootMap event %s", event.InitL1InfoRootMap.String())
 			err = processEventInitL1InfoRootMap(tx, block.Num, event.InitL1InfoRootMap)
 			if err != nil {
 				err = fmt.Errorf("initL1InfoRootMap. Err: %w", err)
-				log.Errorf("error processing InitL1InfoRootMap: %v", err)
+				p.log.Errorf("error processing InitL1InfoRootMap: %v", err)
 				return err
 			}
 		}
@@ -395,7 +402,7 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 	}
 	shouldRollback = false
 
-	log.Infof("block %d processed with %d events", block.Num, len(block.Events))
+	p.log.Infof("block %d processed with %d events", block.Num, len(block.Events))
 	return nil
 }
 

--- a/reorgdetector/reorgdetector.go
+++ b/reorgdetector/reorgdetector.go
@@ -18,6 +18,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type Network string
+
+const (
+	L1 Network = "l1"
+	L2 Network = "l2"
+)
+
+func (n Network) String() string {
+	return string(n)
+}
+
 type EthClient interface {
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
@@ -34,9 +45,11 @@ type ReorgDetector struct {
 
 	subscriptionsLock sync.RWMutex
 	subscriptions     map[string]*Subscription
+
+	log *log.Logger
 }
 
-func New(client EthClient, cfg Config) (*ReorgDetector, error) {
+func New(client EthClient, cfg Config, network Network) (*ReorgDetector, error) {
 	err := migrations.RunMigrations(cfg.DBPath)
 	if err != nil {
 		return nil, err
@@ -52,6 +65,7 @@ func New(client EthClient, cfg Config) (*ReorgDetector, error) {
 		checkReorgInterval: cfg.GetCheckReorgsInterval(),
 		trackedBlocks:      make(map[string]*headersList),
 		subscriptions:      make(map[string]*Subscription),
+		log:                log.WithFields("reorg-detector", network.String()),
 	}, nil
 }
 
@@ -121,6 +135,8 @@ func (rd *ReorgDetector) detectReorgInTrackedList(ctx context.Context) error {
 		}
 		errGroup errgroup.Group
 	)
+
+	rd.log.Infof("Checking reorgs in tracked blocks up to block %d", lastFinalisedBlock.Number.Uint64())
 
 	subscriberIDs := rd.getSubscriberIDs()
 

--- a/reorgdetector/reorgdetector_db.go
+++ b/reorgdetector/reorgdetector_db.go
@@ -60,6 +60,9 @@ func (rd *ReorgDetector) saveTrackedBlock(id string, b header) error {
 		hdrs.add(b)
 	}
 	rd.trackedBlocksLock.Unlock()
+
+	rd.log.Debugf("Tracking block %d for subscriber %s", b.Num, id)
+
 	return meddler.Insert(rd.db, "tracked_block", &headerWithSubscriberID{
 		SubscriberID: id,
 		Num:          b.Num,

--- a/reorgdetector/reorgdetector_sub.go
+++ b/reorgdetector/reorgdetector_sub.go
@@ -37,6 +37,8 @@ func (rd *ReorgDetector) notifySubscriber(id string, startingBlock header) {
 	sub, ok := rd.subscriptions[id]
 	rd.subscriptionsLock.RUnlock()
 
+	rd.log.Infof("Reorg detected for subscriber %s at block %d", id, startingBlock.Num)
+
 	if ok {
 		sub.ReorgedBlock <- startingBlock.Num
 		<-sub.ReorgProcessed

--- a/reorgdetector/reorgdetector_test.go
+++ b/reorgdetector/reorgdetector_test.go
@@ -24,7 +24,7 @@ func Test_ReorgDetector(t *testing.T) {
 	// Create test DB dir
 	testDir := path.Join(t.TempDir(), "file::memory:?cache=shared")
 
-	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)})
+	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)}, L1)
 	require.NoError(t, err)
 
 	err = reorgDetector.Start(ctx)
@@ -76,7 +76,7 @@ func Test_ReorgDetector(t *testing.T) {
 func TestGetTrackedBlocks(t *testing.T) {
 	clientL1, _ := helpers.SimulatedBackend(t, nil, 0)
 	testDir := path.Join(t.TempDir(), "file::memory:?cache=shared")
-	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)})
+	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)}, L1)
 	require.NoError(t, err)
 	list, err := reorgDetector.getTrackedBlocks()
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestGetTrackedBlocks(t *testing.T) {
 func TestNotSubscribed(t *testing.T) {
 	clientL1, _ := helpers.SimulatedBackend(t, nil, 0)
 	testDir := path.Join(t.TempDir(), "file::memory:?cache=shared")
-	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)})
+	reorgDetector, err := New(clientL1.Client(), Config{DBPath: testDir, CheckReorgsInterval: cdktypes.NewDuration(time.Millisecond * 100)}, L1)
 	require.NoError(t, err)
 	err = reorgDetector.AddBlockToTrack(context.Background(), "foo", 1, common.Hash{})
 	require.True(t, strings.Contains(err.Error(), "is not subscribed"))

--- a/sync/driver.go
+++ b/sync/driver.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var ErrInconsistentState = errors.New("state is inconsistent, try again later once the state is consolidated")
@@ -10,6 +12,7 @@ var ErrInconsistentState = errors.New("state is inconsistent, try again later on
 type Block struct {
 	Num    uint64
 	Events []interface{}
+	Hash   common.Hash
 }
 
 type ProcessorInterface interface {

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -76,7 +76,7 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 	for {
 		select {
 		case <-ctx.Done():
-			d.log.Debug("closing channel")
+			d.log.Info("closing evm downloader channel")
 			close(downloadedCh)
 			return
 		default:

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -101,7 +101,7 @@ reset:
 			d.log.Debugf("handleNewBlock, blockNum: %d, blockHash: %s", b.Num, b.Hash)
 			d.handleNewBlock(ctx, cancel, b)
 		case firstReorgedBlock := <-d.reorgSub.ReorgedBlock:
-			d.log.Debug("handleReorg from block: ", firstReorgedBlock)
+			d.log.Info("handleReorg from block: ", firstReorgedBlock)
 			d.handleReorg(ctx, cancel, firstReorgedBlock)
 			goto reset
 		}
@@ -143,6 +143,7 @@ func (d *EVMDriver) handleNewBlock(ctx context.Context, cancel context.CancelFun
 			blockToProcess := Block{
 				Num:    b.Num,
 				Events: b.Events,
+				Hash:   b.Hash,
 			}
 			err := d.processor.ProcessBlock(ctx, blockToProcess)
 			if err != nil {

--- a/sync/evmdriver_test.go
+++ b/sync/evmdriver_test.go
@@ -91,11 +91,11 @@ func TestSync(t *testing.T) {
 		Return(uint64(3), nil)
 	rdm.On("AddBlockToTrack", ctx, reorgDetectorID, expectedBlock1.Num, expectedBlock1.Hash).
 		Return(nil)
-	pm.On("ProcessBlock", ctx, Block{Num: expectedBlock1.Num, Events: expectedBlock1.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: expectedBlock1.Num, Events: expectedBlock1.Events, Hash: expectedBlock1.Hash}).
 		Return(nil)
 	rdm.On("AddBlockToTrack", ctx, reorgDetectorID, expectedBlock2.Num, expectedBlock2.Hash).
 		Return(nil)
-	pm.On("ProcessBlock", ctx, Block{Num: expectedBlock2.Num, Events: expectedBlock2.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: expectedBlock2.Num, Events: expectedBlock2.Events, Hash: expectedBlock2.Hash}).
 		Return(nil)
 	go driver.Sync(ctx)
 	time.Sleep(time.Millisecond * 200) // time to download expectedBlock1
@@ -142,7 +142,7 @@ func TestHandleNewBlock(t *testing.T) {
 	rdm.
 		On("AddBlockToTrack", ctx, reorgDetectorID, b1.Num, b1.Hash).
 		Return(nil)
-	pm.On("ProcessBlock", ctx, Block{Num: b1.Num, Events: b1.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: b1.Num, Events: b1.Events, Hash: b1.Hash}).
 		Return(nil)
 	driver.handleNewBlock(ctx, nil, b1)
 
@@ -159,7 +159,7 @@ func TestHandleNewBlock(t *testing.T) {
 	rdm.
 		On("AddBlockToTrack", ctx, reorgDetectorID, b2.Num, b2.Hash).
 		Return(nil).Once()
-	pm.On("ProcessBlock", ctx, Block{Num: b2.Num, Events: b2.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: b2.Num, Events: b2.Events, Hash: b2.Hash}).
 		Return(nil)
 	driver.handleNewBlock(ctx, nil, b2)
 
@@ -173,9 +173,9 @@ func TestHandleNewBlock(t *testing.T) {
 	rdm.
 		On("AddBlockToTrack", ctx, reorgDetectorID, b3.Num, b3.Hash).
 		Return(nil)
-	pm.On("ProcessBlock", ctx, Block{Num: b3.Num, Events: b3.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: b3.Num, Events: b3.Events, Hash: b3.Hash}).
 		Return(errors.New("foo")).Once()
-	pm.On("ProcessBlock", ctx, Block{Num: b3.Num, Events: b3.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: b3.Num, Events: b3.Events, Hash: b3.Hash}).
 		Return(nil).Once()
 	driver.handleNewBlock(ctx, nil, b3)
 
@@ -189,7 +189,7 @@ func TestHandleNewBlock(t *testing.T) {
 	rdm.
 		On("AddBlockToTrack", ctx, reorgDetectorID, b4.Num, b4.Hash).
 		Return(nil)
-	pm.On("ProcessBlock", ctx, Block{Num: b4.Num, Events: b4.Events}).
+	pm.On("ProcessBlock", ctx, Block{Num: b4.Num, Events: b4.Events, Hash: b4.Hash}).
 		Return(ErrInconsistentState)
 	cancelIsCalled := false
 	cancel := func() {

--- a/test/aggoraclehelpers/aggoracle_e2e.go
+++ b/test/aggoraclehelpers/aggoracle_e2e.go
@@ -106,7 +106,7 @@ func CommonSetup(t *testing.T) (
 
 	// Reorg detector
 	dbPathReorgDetector := path.Join(t.TempDir(), "file::memory:?cache=shared")
-	reorg, err := reorgdetector.New(l1Client.Client(), reorgdetector.Config{DBPath: dbPathReorgDetector})
+	reorg, err := reorgdetector.New(l1Client.Client(), reorgdetector.Config{DBPath: dbPathReorgDetector}, reorgdetector.L1)
 	require.NoError(t, err)
 
 	// Syncer


### PR DESCRIPTION
## Description

This PR adds a new column to the `l1infotreesyncer.block` table called hash which stores the block hash as well.

Also, it adds additional logs to the `evm driver`, `downloader` and `reorg detector` to try to catch the inconsistent state error that happens on the `l1infotreesyncer`.

Fixes # (issue)
