### PR TITLE
fix: multi chains pessimistic proofs e2e tests

### DIFF
--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -43,14 +43,6 @@ jobs:
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk
-    
-    - name: Install polycli
-      run: |
-        git clone https://github.com/0xPolygon/polygon-cli -b jhilliard/alonso
-        cd polygon-cli
-        make install
-        cp ~/go/bin/polycli /usr/local/bin/polycli
-        /usr/local/bin/polycli version
 
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -1,11 +1,10 @@
-# based on: https://github.com/0xPolygon/kurtosis-cdk/blob/jhilliard/multi-pp-testing/multi-pp-test.sh.md
+# based on: https://github.com/0xPolygon/kurtosis-cdk/tree/main/docs/multi-pp-testing
 name: Test e2e multi pp
 on: 
   push:
     branches:
       - '**'
   workflow_dispatch: {}
-
 
 jobs:
   test-e2e-multi_pp:

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -27,7 +27,6 @@ jobs:
         go-version: ${{ matrix.go-version }}
       env:
         GOARCH: ${{ matrix.goarch }}
-      
 
     - name: Build Docker
       run: make build-docker
@@ -35,12 +34,12 @@ jobs:
     - name: Build Tools
       run: make build-tools
       
-    - name: Checkout kurtosis-cdk
+    - name: Checkout Kurtosis CDK
       uses: actions/checkout@v4
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: jhilliard/multi-pp-testing
+        ref: v0.2.26
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - uses: actions/setup-go@v5
       with:
         go-version: 1.22.x
@@ -44,9 +46,6 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-
-    - name: Build Docker
-      run: make build-docker
     
     - name: Checkout Kurtosis CDK
       uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.26
+        ref: v0.2.25
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -42,24 +42,18 @@ jobs:
           - "fork12-rollup"
           - "fork12-pessimistic"
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Checkout kurtosis-cdk repository
+    - name: Checkout Code
       uses: actions/checkout@v4
-      with:
-        go-version: ${{ matrix.go-version }}
-      env:
-        GOARCH: ${{ matrix.goarch }}
 
     - name: Build Docker
       run: make build-docker
     
-    - name: Checkout kurtosis-cdk
+    - name: Checkout Kurtosis CDK
       uses: actions/checkout@v4
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.24
+        ref: v0.2.26
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -27,7 +27,7 @@ args:
 
 
   cdk_node_image: cdk:latest
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []
   consensus_contract_type: pessimistic

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -29,6 +29,8 @@ args:
   cdk_node_image: cdk:latest
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
+  zkevm_bridge_proxy_image: haproxy:3.0-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -29,8 +29,8 @@ args:
   cdk_node_image: cdk:latest
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
-  zkevm_bridge_proxy_image: haproxy:3.0-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
+  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC6
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -29,8 +29,6 @@ args:
   cdk_node_image: cdk:latest
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
-  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC6
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,7 +1,7 @@
 args:
   cdk_node_image: cdk:latest
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []
   consensus_contract_type: pessimistic

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -3,8 +3,8 @@ args:
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
-  zkevm_bridge_proxy_image: haproxy:3.0-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
+  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC6
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -4,7 +4,7 @@ args:
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   zkevm_bridge_proxy_image: haproxy:3.1-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC6
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC5
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -3,6 +3,8 @@ args:
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
+  zkevm_bridge_proxy_image: haproxy:3.0-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -2,8 +2,8 @@ args:
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   cdk_node_image: cdk
-  zkevm_bridge_proxy_image: haproxy:3.0-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
+  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC6
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -3,7 +3,7 @@ args:
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   cdk_node_image: cdk
   zkevm_bridge_proxy_image: haproxy:3.1-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC6
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC5
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,6 +1,6 @@
 args:
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta8
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2-beta8
   cdk_node_image: cdk
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,6 +1,6 @@
 args:
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.20
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2-beta8
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.2
   cdk_node_image: cdk
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1


### PR DESCRIPTION
## Description

Bump the Kurtosis CDK version (https://github.com/0xPolygon/kurtosis-cdk/releases/tag/v0.2.26), because the transient branch, `jhilliard/multi-pp-testing` was merged in a meantime.

Fixes # (issue)
