### PR TITLE
fix: `reorg detector` and `syncer` issues on `develop`

### DIFF
--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -45,6 +45,7 @@ func NewL1(
 	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
+	finalizedBlockType etherman.BlockNumberFinality,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -61,6 +62,7 @@ func NewL1(
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		syncFullClaims,
+		finalizedBlockType,
 	)
 }
 
@@ -79,6 +81,7 @@ func NewL2(
 	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
+	finalizedBlockType etherman.BlockNumberFinality,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -95,6 +98,7 @@ func NewL2(
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		syncFullClaims,
+		finalizedBlockType,
 	)
 }
 
@@ -113,6 +117,7 @@ func newBridgeSync(
 	maxRetryAttemptsAfterError int,
 	originNetwork uint32,
 	syncFullClaims bool,
+	finalizedBlockType etherman.BlockNumberFinality,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("bridge-syncer", layerID)
 	processor, err := newProcessor(dbPath, logger)
@@ -151,6 +156,7 @@ func newBridgeSync(
 		appender,
 		[]common.Address{bridge},
 		rh,
+		finalizedBlockType,
 	)
 	if err != nil {
 		return nil, err

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	bridgeSyncL1       = "L1"
-	bridgeSyncL2       = "L2"
+	bridgeSyncL1       = "BridgeSyncL1"
+	bridgeSyncL2       = "BridgeSyncL2"
 	downloadBufferSize = 1000
 )
 

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -56,6 +56,7 @@ func TestNewLx(t *testing.T) {
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
+		blockFinalityType,
 	)
 
 	assert.NoError(t, err)
@@ -77,6 +78,7 @@ func TestNewLx(t *testing.T) {
 		maxRetryAttemptsAfterError,
 		originNetwork,
 		false,
+		blockFinalityType,
 	)
 
 	assert.NoError(t, err)

--- a/bridgesync/e2e_test.go
+++ b/bridgesync/e2e_test.go
@@ -88,6 +88,8 @@ func TestBridgeEventE2E(t *testing.T) {
 		}
 	}
 
+	helpers.CommitBlocks(t, setup.L1Environment.SimBackend, 11, blockTime)
+
 	// Wait for syncer to catch up
 	time.Sleep(time.Second * 2) // sleeping since the processor could be up to date, but have pending reorgs
 	lb, err := setup.L1Environment.SimBackend.Client().BlockNumber(ctx)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -526,6 +526,7 @@ func runL1InfoTreeSyncerIfNeeded(
 		cfg.L1InfoTreeSync.RetryAfterErrorPeriod.Duration,
 		cfg.L1InfoTreeSync.MaxRetryAttemptsAfterError,
 		l1infotreesync.FlagNone,
+		etherman.FinalizedBlock,
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -727,6 +728,7 @@ func runBridgeSyncL1IfNeeded(
 		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
 		false,
+		etherman.FinalizedBlock,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -762,6 +764,7 @@ func runBridgeSyncL2IfNeeded(
 		cfg.MaxRetryAttemptsAfterError,
 		rollupID,
 		true,
+		etherman.LatestBlock,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/etherman/types.go
+++ b/etherman/types.go
@@ -120,6 +120,10 @@ func (b *BlockNumberFinality) ToBlockNum() (*big.Int, error) {
 	}
 }
 
+func (b BlockNumberFinality) IsFinalized() bool {
+	return b == FinalizedBlock
+}
+
 type BlockNumber int64
 
 const (

--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -70,7 +70,7 @@ func TestE2E(t *testing.T) {
 	rdm.On("AddBlockToTrack", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	client, auth, gerAddr, verifyAddr, gerSc, verifySC := newSimulatedClient(t)
-	syncer, err := l1infotreesync.New(ctx, dbPath, gerAddr, verifyAddr, 10, etherman.LatestBlock, rdm, client.Client(), time.Millisecond, 0, 100*time.Millisecond, 3,
+	syncer, err := l1infotreesync.New(ctx, dbPath, gerAddr, verifyAddr, 10, etherman.LatestBlock, rdm, client.Client(), time.Millisecond, 0, 100*time.Millisecond, 25,
 		l1infotreesync.FlagAllowWrongContractsAddrs)
 	require.NoError(t, err)
 
@@ -221,9 +221,6 @@ func TestWithReorgs(t *testing.T) {
 	// Block 4, 5, 6 after the fork
 	helpers.CommitBlocks(t, client, 3, time.Millisecond*500)
 
-	// Make sure syncer is up to date
-	waitForSyncerToCatchUp(ctx, t, syncer, client)
-
 	// Assert rollup exit root after the fork - should be zero since there are no events in the block after the fork
 	expectedRollupExitRoot, err = verifySC.GetRollupExitRoot(&bind.CallOpts{Pending: false})
 	require.NoError(t, err)
@@ -236,11 +233,12 @@ func TestWithReorgs(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(time.Millisecond * 500)
 
+	helpers.CommitBlocks(t, client, 1, time.Millisecond*100)
+
 	// create some events and update the trees
 	updateL1InfoTreeAndRollupExitTree(2, 1)
 
-	// Block 4, 5, 6, 7 after the fork
-	helpers.CommitBlocks(t, client, 4, time.Millisecond*100)
+	helpers.CommitBlocks(t, client, 1, time.Millisecond*100)
 
 	// Make sure syncer is up to date
 	waitForSyncerToCatchUp(ctx, t, syncer, client)
@@ -305,7 +303,7 @@ func TestStressAndReorgs(t *testing.T) {
 		}
 	}
 
-	helpers.CommitBlocks(t, client, 1, time.Millisecond*10)
+	helpers.CommitBlocks(t, client, 11, time.Millisecond*10)
 
 	waitForSyncerToCatchUp(ctx, t, syncer, client)
 

--- a/l1infotreesync/e2e_test.go
+++ b/l1infotreesync/e2e_test.go
@@ -71,7 +71,7 @@ func TestE2E(t *testing.T) {
 
 	client, auth, gerAddr, verifyAddr, gerSc, verifySC := newSimulatedClient(t)
 	syncer, err := l1infotreesync.New(ctx, dbPath, gerAddr, verifyAddr, 10, etherman.LatestBlock, rdm, client.Client(), time.Millisecond, 0, 100*time.Millisecond, 25,
-		l1infotreesync.FlagAllowWrongContractsAddrs)
+		l1infotreesync.FlagAllowWrongContractsAddrs, etherman.SafeBlock)
 	require.NoError(t, err)
 
 	go syncer.Start(ctx)
@@ -159,7 +159,7 @@ func TestWithReorgs(t *testing.T) {
 	require.NoError(t, rd.Start(ctx))
 
 	syncer, err := l1infotreesync.New(ctx, dbPathSyncer, gerAddr, verifyAddr, 10, etherman.LatestBlock, rd, client.Client(), time.Millisecond, 0, time.Second, 25,
-		l1infotreesync.FlagAllowWrongContractsAddrs)
+		l1infotreesync.FlagAllowWrongContractsAddrs, etherman.SafeBlock)
 	require.NoError(t, err)
 	go syncer.Start(ctx)
 
@@ -272,7 +272,7 @@ func TestStressAndReorgs(t *testing.T) {
 	require.NoError(t, rd.Start(ctx))
 
 	syncer, err := l1infotreesync.New(ctx, dbPathSyncer, gerAddr, verifyAddr, 10, etherman.LatestBlock, rd, client.Client(), time.Millisecond, 0, time.Second, 100,
-		l1infotreesync.FlagAllowWrongContractsAddrs)
+		l1infotreesync.FlagAllowWrongContractsAddrs, etherman.SafeBlock)
 	require.NoError(t, err)
 	go syncer.Start(ctx)
 

--- a/l1infotreesync/l1infotreesync.go
+++ b/l1infotreesync/l1infotreesync.go
@@ -47,6 +47,7 @@ func New(
 	retryAfterErrorPeriod time.Duration,
 	maxRetryAttemptsAfterError int,
 	flags CreationFlags,
+	finalizedBlockType etherman.BlockNumberFinality,
 ) (*L1InfoTreeSync, error) {
 	processor, err := newProcessor(dbPath)
 	if err != nil {
@@ -83,6 +84,7 @@ func New(
 		appender,
 		[]common.Address{globalExitRoot, rollupManager},
 		rh,
+		finalizedBlockType,
 	)
 	if err != nil {
 		return nil, err

--- a/l1infotreesync/processor.go
+++ b/l1infotreesync/processor.go
@@ -242,7 +242,6 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 	shouldRollback := true
 	defer func() {
 		if shouldRollback {
-			log.Debugf("rolling back reorg, first reorged block: %d", firstReorgedBlock)
 			if errRllbck := tx.Rollback(); errRllbck != nil {
 				log.Errorf("error while rolling back tx %v", errRllbck)
 			}
@@ -269,6 +268,9 @@ func (p *processor) Reorg(ctx context.Context, firstReorgedBlock uint64) error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
+
+	shouldRollback = false
+
 	sync.UnhaltIfAffectedRows(&p.halted, &p.haltedReason, &p.mu, rowsAffected)
 	return nil
 }

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -58,19 +58,27 @@ func NewEVMDownloader(
 	if err != nil {
 		return nil, err
 	}
+
 	topicsToQuery := make([]common.Hash, 0, len(appender))
 	for topic := range appender {
 		topicsToQuery = append(topicsToQuery, topic)
 	}
+
+	fbtEthermanType := finalizedBlockType
 	fbt, err := finalizedBlockType.ToBlockNum()
 	if err != nil {
 		return nil, err
 	}
+
 	if fbt.Cmp(finality) > 0 {
 		// if someone configured the syncer to query blocks by Safe or Finalized block
 		// finalized block type should be at least the same as the block finality
 		fbt = finality
+		fbtEthermanType = blockFinalityType
 	}
+
+	logger.Infof("downloader initialized with block finality: %s, finalized block type: %s. SyncChunkSize: %d",
+		blockFinalityType, fbtEthermanType, syncBlockChunkSize)
 
 	return &EVMDownloader{
 		syncBlockChunkSize: syncBlockChunkSize,

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -39,7 +39,8 @@ type LogAppenderMap map[common.Hash]func(b *EVMBlock, l types.Log) error
 type EVMDownloader struct {
 	syncBlockChunkSize uint64
 	EVMDownloaderInterface
-	log *log.Logger
+	log                *log.Logger
+	finalizedBlockType etherman.BlockNumberFinality
 }
 
 func NewEVMDownloader(
@@ -83,6 +84,7 @@ func NewEVMDownloader(
 	return &EVMDownloader{
 		syncBlockChunkSize: syncBlockChunkSize,
 		log:                logger,
+		finalizedBlockType: fbtEthermanType,
 		EVMDownloaderInterface: &EVMDownloaderImplementation{
 			ethClient:              ethClient,
 			blockFinality:          finality,
@@ -136,19 +138,19 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 		blocks := d.GetEventsByBlockRange(ctx, fromBlock, toBlock)
 
 		if toBlock <= lastFinalizedBlockNumber {
-			d.reportBlocks(downloadedCh, blocks)
+			d.reportBlocks(downloadedCh, blocks, lastFinalizedBlockNumber)
 			fromBlock = toBlock + 1
 
 			if blocks.Len() == 0 || blocks[blocks.Len()-1].Num < toBlock {
-				d.reportEmptyBlock(ctx, downloadedCh, toBlock)
+				d.reportEmptyBlock(ctx, downloadedCh, toBlock, lastFinalizedBlockNumber)
 			}
 		} else {
-			d.reportBlocks(downloadedCh, blocks)
+			d.reportBlocks(downloadedCh, blocks, lastFinalizedBlockNumber)
 
 			if blocks.Len() == 0 {
 				if lastFinalizedBlockNumber > fromBlock &&
 					lastFinalizedBlockNumber-fromBlock > d.syncBlockChunkSize {
-					d.reportEmptyBlock(ctx, downloadedCh, fromBlock+d.syncBlockChunkSize)
+					d.reportEmptyBlock(ctx, downloadedCh, fromBlock+d.syncBlockChunkSize, lastFinalizedBlockNumber)
 					fromBlock += d.syncBlockChunkSize + 1
 				}
 			} else {
@@ -158,14 +160,16 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 	}
 }
 
-func (d *EVMDownloader) reportBlocks(downloadedCh chan EVMBlock, blocks []EVMBlock) {
+func (d *EVMDownloader) reportBlocks(downloadedCh chan EVMBlock, blocks EVMBlocks, lastFinalizedBlock uint64) {
 	for _, block := range blocks {
 		d.log.Infof("sending block %d to the driver (with events)", block.Num)
-		downloadedCh <- block
+		block.IsSafeBlock = d.finalizedBlockType.IsFinalized() && block.Num <= lastFinalizedBlock
+		downloadedCh <- *block
 	}
 }
 
-func (d *EVMDownloader) reportEmptyBlock(ctx context.Context, downloadedCh chan EVMBlock, blockNum uint64) {
+func (d *EVMDownloader) reportEmptyBlock(ctx context.Context, downloadedCh chan EVMBlock,
+	blockNum, lastFinalizedBlock uint64) {
 	// Indicate the last downloaded block if there are not events on it
 	d.log.Debugf("sending block %d to the driver (without events)", blockNum)
 	header, isCanceled := d.GetBlockHeader(ctx, blockNum)
@@ -174,6 +178,7 @@ func (d *EVMDownloader) reportEmptyBlock(ctx context.Context, downloadedCh chan 
 	}
 
 	downloadedCh <- EVMBlock{
+		IsSafeBlock:    d.finalizedBlockType.IsFinalized() && header.Num <= lastFinalizedBlock,
 		EVMBlockHeader: header,
 	}
 }
@@ -252,7 +257,7 @@ func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context,
 	case <-ctx.Done():
 		return nil
 	default:
-		blocks := []EVMBlock{}
+		blocks := EVMBlocks{}
 		logs := d.GetLogs(ctx, fromBlock, toBlock)
 		for _, l := range logs {
 			if len(blocks) == 0 || blocks[len(blocks)-1].Num < l.BlockNumber {
@@ -269,7 +274,7 @@ func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context,
 					)
 					return d.GetEventsByBlockRange(ctx, fromBlock, toBlock)
 				}
-				blocks = append(blocks, EVMBlock{
+				blocks = append(blocks, &EVMBlock{
 					EVMBlockHeader: EVMBlockHeader{
 						Num:        l.BlockNumber,
 						Hash:       l.BlockHash,
@@ -282,7 +287,7 @@ func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context,
 
 			for {
 				attempts := 0
-				err := d.appender[l.Topics[0]](&blocks[len(blocks)-1], l)
+				err := d.appender[l.Topics[0]](blocks[len(blocks)-1], l)
 				if err != nil {
 					attempts++
 					d.log.Error("error trying to append log: ", err)

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -135,40 +135,46 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			fromBlock, toBlock, lastFinalizedBlockNumber)
 		blocks := d.GetEventsByBlockRange(ctx, fromBlock, toBlock)
 
-		reportBlocksFn := func(numOfBlocksToReport int) {
-			for i := 0; i < numOfBlocksToReport; i++ {
-				d.log.Infof("sending block %d to the driver (with events)", blocks[i].Num)
-				downloadedCh <- blocks[i]
-			}
-		}
-
-		reportEmptyBlockFn := func(blockNum uint64) {
-			// Indicate the last downloaded block if there are not events on it
-			d.log.Debugf("sending block %d to the driver (without events)", toBlock)
-			header, isCanceled := d.GetBlockHeader(ctx, blockNum)
-			if isCanceled {
-				return
-			}
-
-			downloadedCh <- EVMBlock{
-				EVMBlockHeader: header,
-			}
-		}
-
 		if toBlock <= lastFinalizedBlockNumber {
-			reportBlocksFn(blocks.Len())
+			d.reportBlocks(downloadedCh, blocks)
 			fromBlock = toBlock + 1
 
 			if blocks.Len() == 0 || blocks[blocks.Len()-1].Num < toBlock {
-				reportEmptyBlockFn(toBlock)
+				d.reportEmptyBlock(ctx, downloadedCh, toBlock)
 			}
 		} else {
-			lastFinalizedBlockNum, i, found := blocks.LastFinalizedBlock(lastFinalizedBlockNumber)
-			if found {
-				reportBlocksFn(i + 1)
-				fromBlock = lastFinalizedBlockNum + 1
+			d.reportBlocks(downloadedCh, blocks)
+
+			if blocks.Len() == 0 {
+				if lastFinalizedBlockNumber > fromBlock &&
+					lastFinalizedBlockNumber-fromBlock > d.syncBlockChunkSize {
+					d.reportEmptyBlock(ctx, downloadedCh, fromBlock+d.syncBlockChunkSize)
+					fromBlock += d.syncBlockChunkSize + 1
+				}
+			} else {
+				fromBlock = blocks[blocks.Len()-1].Num + 1
 			}
 		}
+	}
+}
+
+func (d *EVMDownloader) reportBlocks(downloadedCh chan EVMBlock, blocks []EVMBlock) {
+	for _, block := range blocks {
+		d.log.Infof("sending block %d to the driver (with events)", block.Num)
+		downloadedCh <- block
+	}
+}
+
+func (d *EVMDownloader) reportEmptyBlock(ctx context.Context, downloadedCh chan EVMBlock, blockNum uint64) {
+	// Indicate the last downloaded block if there are not events on it
+	d.log.Debugf("sending block %d to the driver (without events)", blockNum)
+	header, isCanceled := d.GetBlockHeader(ctx, blockNum)
+	if isCanceled {
+		return
+	}
+
+	downloadedCh <- EVMBlock{
+		EVMBlockHeader: header,
 	}
 }
 

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -76,6 +76,8 @@ func NewEVMDownloader(
 		// finalized block type should be at least the same as the block finality
 		fbt = finality
 		fbtEthermanType = blockFinalityType
+		logger.Warnf("finalized block type %s is greater than block finality %s, setting finalized block type to %s",
+			finalizedBlockType, blockFinalityType, fbtEthermanType)
 	}
 
 	logger.Infof("downloader initialized with block finality: %s, finalized block type: %s. SyncChunkSize: %d",
@@ -163,7 +165,7 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 func (d *EVMDownloader) reportBlocks(downloadedCh chan EVMBlock, blocks EVMBlocks, lastFinalizedBlock uint64) {
 	for _, block := range blocks {
 		d.log.Infof("sending block %d to the driver (with events)", block.Num)
-		block.IsSafeBlock = d.finalizedBlockType.IsFinalized() && block.Num <= lastFinalizedBlock
+		block.IsFinalizedBlock = d.finalizedBlockType.IsFinalized() && block.Num <= lastFinalizedBlock
 		downloadedCh <- *block
 	}
 }
@@ -178,8 +180,8 @@ func (d *EVMDownloader) reportEmptyBlock(ctx context.Context, downloadedCh chan 
 	}
 
 	downloadedCh <- EVMBlock{
-		IsSafeBlock:    d.finalizedBlockType.IsFinalized() && header.Num <= lastFinalizedBlock,
-		EVMBlockHeader: header,
+		IsFinalizedBlock: d.finalizedBlockType.IsFinalized() && header.Num <= lastFinalizedBlock,
+		EVMBlockHeader:   header,
 	}
 }
 

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -81,7 +81,6 @@ func NewEVMDownloader(
 func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, downloadedCh chan EVMBlock) {
 	lastBlock := d.WaitForNewBlocks(ctx, 0)
 	toBlock := fromBlock
-	automaticToBlockResize := true
 
 	for {
 		select {
@@ -92,14 +91,10 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 		default:
 		}
 
-		if automaticToBlockResize {
-			toBlock = fromBlock + d.syncBlockChunkSize
-			if toBlock > lastBlock {
-				toBlock = lastBlock
-			}
+		toBlock = fromBlock + d.syncBlockChunkSize
+		if toBlock > lastBlock {
+			toBlock = lastBlock
 		}
-
-		automaticToBlockResize = true // reset the flag
 
 		if fromBlock > toBlock {
 			d.log.Debugf(
@@ -145,9 +140,8 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			// we have no events, keep increasing the block range until we hit a log
 			if lastFinalizedBlockNumber > toBlock {
 				// we might be behind a lot, so go until last finalized block
-				toBlock = lastFinalizedBlockNumber + 1
-			} else {
-				toBlock++
+				toBlock = lastFinalizedBlockNumber
+				lastBlock = lastFinalizedBlockNumber
 			}
 
 			if lastFinalizedBlockNumber-fromBlock >= d.syncBlockChunkSize {
@@ -158,15 +152,13 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 				fromBlock = lastFinalizedBlockNumber
 			}
 
-			automaticToBlockResize = false
-
 			continue
 		} else if blocks[blocks.Len()-1].Num <= lastFinalizedBlockNumber {
 			// if the last block we have logs for is less than or equal to the last finalized block,
 			// report all of the blocks without the need to report the last empty block, since it is finalized
 			// and we do not need to track it in the reorg detector
 			reportBlocksFn(blocks.Len())
-			fromBlock = lastFinalizedBlockNumber + 1
+			fromBlock = toBlock + 1
 		} else if blocks[blocks.Len()-1].Num < toBlock {
 			// if we have logs in some of the blocks, and they are not all finalized,
 			// check if we have finalized blocks in gotten range, report them and

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -167,10 +167,11 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			// and we do not need to track it in the reorg detector
 			reportBlocksFn(blocks.Len())
 			fromBlock = lastFinalizedBlockNumber + 1
-		} else if blocks[len(blocks)-1].Num < toBlock {
+		} else if blocks[blocks.Len()-1].Num < toBlock {
 			// if we have logs in some of the blocks, and they are not all finalized,
 			// check if we have finalized blocks in gotten range, report them and
 			// set the from block from the last finalized block and keep increasing the range
+			// if not keep getting that range to protect us from possible mishandling of block hashes
 			lastFinalizedBlock, index, exists := blocks.LastFinalizedBlock(lastFinalizedBlockNumber)
 			if exists {
 				reportBlocksFn(index + 1) // num of blocks to report is index + 1 since index is zero based

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 const (
@@ -28,9 +29,10 @@ type EthClienter interface {
 
 type EVMDownloaderInterface interface {
 	WaitForNewBlocks(ctx context.Context, lastBlockSeen uint64) (newLastBlock uint64)
-	GetEventsByBlockRange(ctx context.Context, fromBlock, toBlock uint64) []EVMBlock
+	GetEventsByBlockRange(ctx context.Context, fromBlock, toBlock uint64) EVMBlocks
 	GetLogs(ctx context.Context, fromBlock, toBlock uint64) []types.Log
 	GetBlockHeader(ctx context.Context, blockNum uint64) (EVMBlockHeader, bool)
+	GetLastFinalizedBlock(ctx context.Context) (*types.Header, error)
 }
 
 type LogAppenderMap map[common.Hash]func(b *EVMBlock, l types.Log) error
@@ -78,6 +80,9 @@ func NewEVMDownloader(
 
 func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, downloadedCh chan EVMBlock) {
 	lastBlock := d.WaitForNewBlocks(ctx, 0)
+	toBlock := fromBlock
+	automaticToBlockResize := true
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -86,10 +91,16 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			return
 		default:
 		}
-		toBlock := fromBlock + d.syncBlockChunkSize
-		if toBlock > lastBlock {
-			toBlock = lastBlock
+
+		if automaticToBlockResize {
+			toBlock = fromBlock + d.syncBlockChunkSize
+			if toBlock > lastBlock {
+				toBlock = lastBlock
+			}
 		}
+
+		automaticToBlockResize = true // reset the flag
+
 		if fromBlock > toBlock {
 			d.log.Debugf(
 				"waiting for new blocks, last block processed: %d, last block seen on L1: %d",
@@ -98,16 +109,29 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			lastBlock = d.WaitForNewBlocks(ctx, fromBlock-1)
 			continue
 		}
-		d.log.Debugf("getting events from block %d to %d", fromBlock, toBlock)
-		blocks := d.GetEventsByBlockRange(ctx, fromBlock, toBlock)
-		for _, b := range blocks {
-			d.log.Debugf("sending block %d to the driver (with events)", b.Num)
-			downloadedCh <- b
+
+		lastFinalizedBlock, err := d.GetLastFinalizedBlock(ctx)
+		if err != nil {
+			d.log.Error("error getting last finalized block: ", err)
+			continue
 		}
-		if len(blocks) == 0 || blocks[len(blocks)-1].Num < toBlock {
+
+		lastFinalizedBlockNumber := lastFinalizedBlock.Number.Uint64()
+
+		d.log.Debugf("getting events from blocks %d to  %d", fromBlock, toBlock)
+		blocks := d.GetEventsByBlockRange(ctx, fromBlock, toBlock)
+
+		reportBlocksFn := func(numOfBlocksToReport int) {
+			for i := 0; i < numOfBlocksToReport; i++ {
+				d.log.Debugf("sending block %d to the driver (with events)", blocks[i].Num)
+				downloadedCh <- blocks[i]
+			}
+		}
+
+		reportEmptyBlockFn := func(blockNum uint64) {
 			// Indicate the last downloaded block if there are not events on it
 			d.log.Debugf("sending block %d to the driver (without events)", toBlock)
-			header, isCanceled := d.GetBlockHeader(ctx, toBlock)
+			header, isCanceled := d.GetBlockHeader(ctx, blockNum)
 			if isCanceled {
 				return
 			}
@@ -116,7 +140,50 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 				EVMBlockHeader: header,
 			}
 		}
-		fromBlock = toBlock + 1
+
+		if blocks.Len() == 0 {
+			// we have no events, keep increasing the block range until we hit a log
+			if lastFinalizedBlockNumber > toBlock {
+				// we might be behind a lot, so go until last finalized block
+				toBlock = lastFinalizedBlockNumber + 1
+			} else {
+				toBlock++
+			}
+
+			if lastFinalizedBlockNumber-fromBlock >= d.syncBlockChunkSize {
+				// if we already got a lot of finalized blocks that are empty, report an empty block
+				// to the driver to indicate that we are still processing the chain
+				// this is mainly needed for tests
+				reportEmptyBlockFn(lastFinalizedBlockNumber)
+				fromBlock = lastFinalizedBlockNumber
+			}
+
+			automaticToBlockResize = false
+
+			continue
+		} else if blocks[blocks.Len()-1].Num <= lastFinalizedBlockNumber {
+			// if the last block we have logs for is less than or equal to the last finalized block,
+			// report all of the blocks without the need to report the last empty block, since it is finalized
+			// and we do not need to track it in the reorg detector
+			reportBlocksFn(blocks.Len())
+			fromBlock = lastFinalizedBlockNumber + 1
+		} else if blocks[len(blocks)-1].Num < toBlock {
+			// if we have logs in some of the blocks, and they are not all finalized,
+			// check if we have finalized blocks in gotten range, report them and
+			// set the from block from the last finalized block and keep increasing the range
+			lastFinalizedBlock, index, exists := blocks.LastFinalizedBlock(lastFinalizedBlockNumber)
+			if exists {
+				reportBlocksFn(index + 1) // num of blocks to report is index + 1 since index is zero based
+				fromBlock = lastFinalizedBlock + 1
+				continue
+			}
+		} else {
+			// if we have logs in the last block, just report all of them and continue
+			// reorg detector will handle the reorg since the last block has events,
+			// and we are not afraid to have missaligned hashes at this point
+			reportBlocksFn(blocks.Len())
+			fromBlock = toBlock + 1
+		}
 	}
 }
 
@@ -154,6 +221,10 @@ func NewEVMDownloaderImplementation(
 	}
 }
 
+func (d *EVMDownloaderImplementation) GetLastFinalizedBlock(ctx context.Context) (*types.Header, error) {
+	return d.ethClient.HeaderByNumber(ctx, big.NewInt(int64(rpc.SafeBlockNumber)))
+}
+
 func (d *EVMDownloaderImplementation) WaitForNewBlocks(
 	ctx context.Context, lastBlockSeen uint64,
 ) (newLastBlock uint64) {
@@ -184,7 +255,7 @@ func (d *EVMDownloaderImplementation) WaitForNewBlocks(
 	}
 }
 
-func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context, fromBlock, toBlock uint64) []EVMBlock {
+func (d *EVMDownloaderImplementation) GetEventsByBlockRange(ctx context.Context, fromBlock, toBlock uint64) EVMBlocks {
 	select {
 	case <-ctx.Done():
 		return nil

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -136,52 +136,19 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			}
 		}
 
-		if blocks.Len() == 0 {
-			// we have no events, keep increasing the block range until we hit a log
-			d.log.Infof("no events found in blocks %d to %d", fromBlock, toBlock)
-			if lastFinalizedBlockNumber > toBlock {
-				// we might be behind a lot, so go until last finalized block
-				toBlock = lastFinalizedBlockNumber
-				lastBlock = lastFinalizedBlockNumber
-				d.log.Infof("setting toBlock to last finalized block %d", toBlock)
-			}
-
-			if lastFinalizedBlockNumber > fromBlock && lastFinalizedBlockNumber-fromBlock >= d.syncBlockChunkSize {
-				// if we already got a lot of finalized blocks that are empty, report an empty block
-				// to the driver to indicate that we are still processing the chain
-				// this is mainly needed for tests
-				reportEmptyBlockFn(lastFinalizedBlockNumber)
-				fromBlock = lastFinalizedBlockNumber
-				d.log.Infof("setting fromBlock to last finalized block %d", fromBlock)
-			}
-
-			continue
-		} else if blocks[blocks.Len()-1].Num <= lastFinalizedBlockNumber {
-			// if the last block we have logs for is less than or equal to the last finalized block,
-			// report all of the blocks without the need to report the last empty block, since it is finalized
-			// and we do not need to track it in the reorg detector
+		if toBlock <= lastFinalizedBlockNumber {
 			reportBlocksFn(blocks.Len())
 			fromBlock = toBlock + 1
-			d.log.Infof("got blocks that are lower than finalized block, setting fromBlock to %d", fromBlock)
-		} else if blocks[blocks.Len()-1].Num < toBlock {
-			// if we have logs in some of the blocks, and they are not all finalized,
-			// check if we have finalized blocks in gotten range, report them and
-			// set the from block from the last finalized block and keep increasing the range
-			// if not keep getting that range to protect us from possible mishandling of block hashes
-			lastFinalizedBlock, index, exists := blocks.LastFinalizedBlock(lastFinalizedBlockNumber)
-			if exists {
-				reportBlocksFn(index + 1) // num of blocks to report is index + 1 since index is zero based
-				fromBlock = lastFinalizedBlock + 1
-				d.log.Infof("have some finalized blocks in the range, setting fromBlock to %d", fromBlock)
-				continue
+
+			if blocks.Len() == 0 || blocks[blocks.Len()-1].Num < toBlock {
+				reportEmptyBlockFn(toBlock)
 			}
 		} else {
-			// if we have logs in the last block, just report all of them and continue
-			// reorg detector will handle the reorg since the last block has events,
-			// and we are not afraid to have missaligned hashes at this point
-			reportBlocksFn(blocks.Len())
-			fromBlock = toBlock + 1
-			d.log.Infof("have logs in the last block, setting fromBlock to %d", fromBlock)
+			lastFinalizedBlockNum, i, found := blocks.LastFinalizedBlock(lastFinalizedBlockNumber)
+			if found {
+				reportBlocksFn(i + 1)
+				fromBlock = lastFinalizedBlockNum + 1
+			}
 		}
 	}
 }

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -80,7 +80,6 @@ func NewEVMDownloader(
 
 func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, downloadedCh chan EVMBlock) {
 	lastBlock := d.WaitForNewBlocks(ctx, 0)
-	toBlock := fromBlock
 
 	for {
 		select {
@@ -91,13 +90,13 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 		default:
 		}
 
-		toBlock = fromBlock + d.syncBlockChunkSize
+		toBlock := fromBlock + d.syncBlockChunkSize
 		if toBlock > lastBlock {
 			toBlock = lastBlock
 		}
 
 		if fromBlock > toBlock {
-			d.log.Debugf(
+			d.log.Infof(
 				"waiting for new blocks, last block processed: %d, last block seen on L1: %d",
 				fromBlock-1, lastBlock,
 			)
@@ -113,12 +112,13 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 
 		lastFinalizedBlockNumber := lastFinalizedBlock.Number.Uint64()
 
-		d.log.Debugf("getting events from blocks %d to  %d", fromBlock, toBlock)
+		d.log.Infof("getting events from blocks %d to  %d. lastFinalizedBlock: %d",
+			fromBlock, toBlock, lastFinalizedBlockNumber)
 		blocks := d.GetEventsByBlockRange(ctx, fromBlock, toBlock)
 
 		reportBlocksFn := func(numOfBlocksToReport int) {
 			for i := 0; i < numOfBlocksToReport; i++ {
-				d.log.Debugf("sending block %d to the driver (with events)", blocks[i].Num)
+				d.log.Infof("sending block %d to the driver (with events)", blocks[i].Num)
 				downloadedCh <- blocks[i]
 			}
 		}
@@ -138,18 +138,21 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 
 		if blocks.Len() == 0 {
 			// we have no events, keep increasing the block range until we hit a log
+			d.log.Infof("no events found in blocks %d to %d", fromBlock, toBlock)
 			if lastFinalizedBlockNumber > toBlock {
 				// we might be behind a lot, so go until last finalized block
 				toBlock = lastFinalizedBlockNumber
 				lastBlock = lastFinalizedBlockNumber
+				d.log.Infof("setting toBlock to last finalized block %d", toBlock)
 			}
 
-			if lastFinalizedBlockNumber-fromBlock >= d.syncBlockChunkSize {
+			if lastFinalizedBlockNumber > fromBlock && lastFinalizedBlockNumber-fromBlock >= d.syncBlockChunkSize {
 				// if we already got a lot of finalized blocks that are empty, report an empty block
 				// to the driver to indicate that we are still processing the chain
 				// this is mainly needed for tests
 				reportEmptyBlockFn(lastFinalizedBlockNumber)
 				fromBlock = lastFinalizedBlockNumber
+				d.log.Infof("setting fromBlock to last finalized block %d", fromBlock)
 			}
 
 			continue
@@ -159,6 +162,7 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			// and we do not need to track it in the reorg detector
 			reportBlocksFn(blocks.Len())
 			fromBlock = toBlock + 1
+			d.log.Infof("got blocks that are lower than finalized block, setting fromBlock to %d", fromBlock)
 		} else if blocks[blocks.Len()-1].Num < toBlock {
 			// if we have logs in some of the blocks, and they are not all finalized,
 			// check if we have finalized blocks in gotten range, report them and
@@ -168,6 +172,7 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			if exists {
 				reportBlocksFn(index + 1) // num of blocks to report is index + 1 since index is zero based
 				fromBlock = lastFinalizedBlock + 1
+				d.log.Infof("have some finalized blocks in the range, setting fromBlock to %d", fromBlock)
 				continue
 			}
 		} else {
@@ -176,6 +181,7 @@ func (d *EVMDownloader) Download(ctx context.Context, fromBlock uint64, download
 			// and we are not afraid to have missaligned hashes at this point
 			reportBlocksFn(blocks.Len())
 			fromBlock = toBlock + 1
+			d.log.Infof("have logs in the last block, setting fromBlock to %d", fromBlock)
 		}
 	}
 }

--- a/sync/evmdownloader.go
+++ b/sync/evmdownloader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rpc"
 )
 
 const (
@@ -52,6 +51,7 @@ func NewEVMDownloader(
 	appender LogAppenderMap,
 	adressessToQuery []common.Address,
 	rh *RetryHandler,
+	finalizedBlockType etherman.BlockNumberFinality,
 ) (*EVMDownloader, error) {
 	logger := log.WithFields("syncer", syncerID)
 	finality, err := blockFinalityType.ToBlockNum()
@@ -62,6 +62,16 @@ func NewEVMDownloader(
 	for topic := range appender {
 		topicsToQuery = append(topicsToQuery, topic)
 	}
+	fbt, err := finalizedBlockType.ToBlockNum()
+	if err != nil {
+		return nil, err
+	}
+	if fbt.Cmp(finality) > 0 {
+		// if someone configured the syncer to query blocks by Safe or Finalized block
+		// finalized block type should be at least the same as the block finality
+		fbt = finality
+	}
+
 	return &EVMDownloader{
 		syncBlockChunkSize: syncBlockChunkSize,
 		log:                logger,
@@ -74,6 +84,7 @@ func NewEVMDownloader(
 			adressessToQuery:       adressessToQuery,
 			rh:                     rh,
 			log:                    logger,
+			finalizedBlockType:     fbt,
 		},
 	}, nil
 }
@@ -162,6 +173,7 @@ type EVMDownloaderImplementation struct {
 	adressessToQuery       []common.Address
 	rh                     *RetryHandler
 	log                    *log.Logger
+	finalizedBlockType     *big.Int
 }
 
 func NewEVMDownloaderImplementation(
@@ -188,7 +200,7 @@ func NewEVMDownloaderImplementation(
 }
 
 func (d *EVMDownloaderImplementation) GetLastFinalizedBlock(ctx context.Context) (*types.Header, error) {
-	return d.ethClient.HeaderByNumber(ctx, big.NewInt(int64(rpc.SafeBlockNumber)))
+	return d.ethClient.HeaderByNumber(ctx, d.finalizedBlockType)
 }
 
 func (d *EVMDownloaderImplementation) WaitForNewBlocks(

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -35,7 +35,7 @@ func TestGetEventsByBlockRange(t *testing.T) {
 		description        string
 		inputLogs          []types.Log
 		fromBlock, toBlock uint64
-		expectedBlocks     []EVMBlock
+		expectedBlocks     EVMBlocks
 	}
 	testCases := []testCase{}
 	ctx := context.Background()
@@ -47,7 +47,7 @@ func TestGetEventsByBlockRange(t *testing.T) {
 		inputLogs:      []types.Log{},
 		fromBlock:      1,
 		toBlock:        3,
-		expectedBlocks: []EVMBlock{},
+		expectedBlocks: EVMBlocks{},
 	}
 	testCases = append(testCases, case0)
 
@@ -56,7 +56,7 @@ func TestGetEventsByBlockRange(t *testing.T) {
 	logsC1 := []types.Log{
 		*logC1,
 	}
-	blocksC1 := []EVMBlock{
+	blocksC1 := EVMBlocks{
 		{
 			EVMBlockHeader: EVMBlockHeader{
 				Num:        logC1.BlockNumber,
@@ -121,7 +121,7 @@ func TestGetEventsByBlockRange(t *testing.T) {
 		*logC3_3,
 		*logC3_4,
 	}
-	blocksC3 := []EVMBlock{
+	blocksC3 := EVMBlocks{
 		{
 			EVMBlockHeader: EVMBlockHeader{
 				Num:        logC3_1.BlockNumber,
@@ -206,32 +206,20 @@ func TestDownload(t *testing.T) {
 	downloadCh := make(chan EVMBlock, 1)
 	ctx := context.Background()
 	ctx1, cancel := context.WithCancel(ctx)
-	expectedBlocks := []EVMBlock{}
+	expectedBlocks := EVMBlocks{}
 	dwnldr, _ := NewTestDownloader(t, time.Millisecond*100)
 	dwnldr.EVMDownloaderInterface = d
 
 	d.On("WaitForNewBlocks", mock.Anything, uint64(0)).
 		Return(uint64(1))
-	// iteratiion 0:
+
+	// iteration 0:
 	// last block is 1, download that block (no events and wait)
-	b1 := EVMBlock{
-		EVMBlockHeader: EVMBlockHeader{
-			Num:  1,
-			Hash: common.HexToHash("01"),
-		},
-	}
-	expectedBlocks = append(expectedBlocks, b1)
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(1)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(1)).
-		Return([]EVMBlock{}, false)
-	d.On("GetBlockHeader", mock.Anything, uint64(1)).
-		Return(b1.EVMBlockHeader, false)
+		Return(EVMBlocks{}, false).Once()
 
-	// iteration 1: wait for next block to be created
-	d.On("WaitForNewBlocks", mock.Anything, uint64(1)).
-		After(time.Millisecond * 100).
-		Return(uint64(2)).Once()
-
-	// iteration 2: block 2 has events
+	// iteration 1: block 2 has events
 	b2 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  2,
@@ -239,15 +227,16 @@ func TestDownload(t *testing.T) {
 		},
 	}
 	expectedBlocks = append(expectedBlocks, b2)
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(2), uint64(2)).
-		Return([]EVMBlock{b2}, false)
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(2)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(2)).
+		Return(EVMBlocks{b2}, false).Once()
 
-	// iteration 3: wait for next block to be created (jump to block 8)
+	// iteration 2: wait for next block to be created (jump to block 8)
 	d.On("WaitForNewBlocks", mock.Anything, uint64(2)).
 		After(time.Millisecond * 100).
 		Return(uint64(8)).Once()
 
-	// iteration 4: blocks 6 and 7 have events
+	// iteration 3: blocks 6 and 7 have events, but last finalized block is 5
 	b6 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  6,
@@ -262,52 +251,62 @@ func TestDownload(t *testing.T) {
 		},
 		Events: []interface{}{"07"},
 	}
-	b8 := EVMBlock{
-		EVMBlockHeader: EVMBlockHeader{
-			Num:  8,
-			Hash: common.HexToHash("08"),
-		},
-	}
-	expectedBlocks = append(expectedBlocks, b6, b7, b8)
+	expectedBlocks = append(expectedBlocks, b6, b7)
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(5)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(3), uint64(8)).
-		Return([]EVMBlock{b6, b7}, false)
-	d.On("GetBlockHeader", mock.Anything, uint64(8)).
-		Return(b8.EVMBlockHeader, false)
+		Return(EVMBlocks{b6, b7}, false)
 
-	// iteration 5: wait for next block to be created (jump to block 30)
-	d.On("WaitForNewBlocks", mock.Anything, uint64(8)).
-		After(time.Millisecond * 100).
-		Return(uint64(30)).Once()
+	// iteration 5: finalized block is now block 8, we report events b6 and b7
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(8)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(3), uint64(8)).
+		Return(EVMBlocks{b6, b7}, false)
 
 	// iteration 6: from block 9 to 19, no events
-	b19 := EVMBlock{
-		EVMBlockHeader: EVMBlockHeader{
-			Num:  19,
-			Hash: common.HexToHash("19"),
-		},
-	}
-	expectedBlocks = append(expectedBlocks, b19)
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(19)).
-		Return([]EVMBlock{}, false)
-	d.On("GetBlockHeader", mock.Anything, uint64(19)).
-		Return(b19.EVMBlockHeader, false)
-
-	// iteration 7: from block 20 to 30, events on last block
-	b30 := EVMBlock{
-		EVMBlockHeader: EVMBlockHeader{
-			Num:  30,
-			Hash: common.HexToHash("30"),
-		},
-		Events: []interface{}{testEvent(common.HexToHash("30"))},
-	}
-	expectedBlocks = append(expectedBlocks, b30)
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(30)).
-		Return([]EVMBlock{b30}, false)
-
-	// iteration 8: wait for next block to be created (jump to block 35)
-	d.On("WaitForNewBlocks", mock.Anything, uint64(30)).
+	d.On("WaitForNewBlocks", mock.Anything, uint64(8)).
 		After(time.Millisecond * 100).
-		Return(uint64(35)).Once()
+		Return(uint64(19)).Once()
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(15)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(19)).
+		Return(EVMBlocks{}, false)
+
+	// iteration 7: last finalized block is now 20, no events, report empty block
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(20)).
+		Return(EVMBlocks{}, false)
+
+	b20 := EVMBlock{
+		EVMBlockHeader: EVMBlockHeader{
+			Num:  20,
+			Hash: common.HexToHash("20"),
+		},
+	}
+	expectedBlocks = append(expectedBlocks, b20)
+	d.On("GetBlockHeader", mock.Anything, uint64(20)).Return(b20.EVMBlockHeader, false) // reporting empty finalized block
+
+	// iteration 8, 9 and 10: last finalized block is still 20, no events
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Times(3)
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(21)).
+		Return(EVMBlocks{}, false)
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(22)).
+		Return(EVMBlocks{}, false)
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(23)).
+		Return(EVMBlocks{}, false)
+
+	// iteration 11: from block 20 to 24, events on last block
+	b24 := EVMBlock{
+		EVMBlockHeader: EVMBlockHeader{
+			Num:  24,
+			Hash: common.HexToHash("24"),
+		},
+		Events: []interface{}{testEvent(common.HexToHash("24"))},
+	}
+	expectedBlocks = append(expectedBlocks, b24)
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(24)).
+		Return(EVMBlocks{b24}, false)
+
+	// iteration 12: closing the downloader
+	d.On("WaitForNewBlocks", mock.Anything, uint64(24)).Return(uint64(25)).After(time.Millisecond * 100).Once()
 
 	go dwnldr.Download(ctx1, 0, downloadCh)
 	for _, expectedBlock := range expectedBlocks {

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -219,7 +219,12 @@ func TestDownload(t *testing.T) {
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(1)).
 		Return(EVMBlocks{}, false).Once()
 
-	// iteration 1: block 2 has events
+	// iteration 1: we have a new block, so increase to block
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(2)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(1)).
+		Return(EVMBlocks{}, false).Once()
+
+	// iteration 2: block 2 has events
 	b2 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  2,
@@ -231,12 +236,12 @@ func TestDownload(t *testing.T) {
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(2)).
 		Return(EVMBlocks{b2}, false).Once()
 
-	// iteration 2: wait for next block to be created (jump to block 8)
+	// iteration 3: wait for next block to be created (jump to block 8)
 	d.On("WaitForNewBlocks", mock.Anything, uint64(2)).
 		After(time.Millisecond * 100).
 		Return(uint64(8)).Once()
 
-	// iteration 3: blocks 6 and 7 have events, but last finalized block is 5
+	// iteration 4: blocks 6 and 7 have events, but last finalized block is 5
 	b6 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  6,
@@ -271,7 +276,7 @@ func TestDownload(t *testing.T) {
 
 	// iteration 7: last finalized block is now 20, no events, report empty block
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(20)).
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(19)).
 		Return(EVMBlocks{}, false)
 
 	b20 := EVMBlock{
@@ -283,16 +288,27 @@ func TestDownload(t *testing.T) {
 	expectedBlocks = append(expectedBlocks, b20)
 	d.On("GetBlockHeader", mock.Anything, uint64(20)).Return(b20.EVMBlockHeader, false) // reporting empty finalized block
 
-	// iteration 8, 9 and 10: last finalized block is still 20, no events
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Times(3)
+	// iteration 8: last finalized block is 21, no events
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(21)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(20)).
+		Return(EVMBlocks{}, false)
+
+	// iteration 9: last finalized block is 22, no events
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(22)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(21)).
 		Return(EVMBlocks{}, false)
+
+	// iteration 10: last finalized block is 23, no events
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(23)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(22)).
 		Return(EVMBlocks{}, false)
+
+	// iteration 11: last finalized block is still 23, no events
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(23)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(23)).
 		Return(EVMBlocks{}, false)
 
-	// iteration 11: from block 20 to 24, events on last block
+	// iteration 12: finalized block is 24, has events
 	b24 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  24,
@@ -301,11 +317,11 @@ func TestDownload(t *testing.T) {
 		Events: []interface{}{testEvent(common.HexToHash("24"))},
 	}
 	expectedBlocks = append(expectedBlocks, b24)
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Once()
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(24)}, nil).Twice()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(24)).
 		Return(EVMBlocks{b24}, false)
 
-	// iteration 12: closing the downloader
+	// iteration 13: closing the downloader
 	d.On("WaitForNewBlocks", mock.Anything, uint64(24)).Return(uint64(25)).After(time.Millisecond * 100).Once()
 
 	go dwnldr.Download(ctx1, 0, downloadCh)

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -86,7 +86,7 @@ func TestGetEventsByBlockRange(t *testing.T) {
 		*logC2_3,
 		*logC2_4,
 	}
-	blocksC2 := []EVMBlock{
+	blocksC2 := []*EVMBlock{
 		{
 			EVMBlockHeader: EVMBlockHeader{
 				Num:        logC2_1.BlockNumber,
@@ -214,8 +214,9 @@ func TestDownload(t *testing.T) {
 		Return(uint64(1))
 
 	lastFinalizedBlock := &types.Header{Number: big.NewInt(1)}
-	createEVMBlockFn := func(header *types.Header) EVMBlock {
-		return EVMBlock{
+	createEVMBlockFn := func(header *types.Header, isSafeBlock bool) *EVMBlock {
+		return &EVMBlock{
+			IsSafeBlock: isSafeBlock,
 			EVMBlockHeader: EVMBlockHeader{
 				Num:        header.Number.Uint64(),
 				Hash:       header.Hash(),
@@ -227,7 +228,7 @@ func TestDownload(t *testing.T) {
 
 	// iteration 0:
 	// last block is 1, download that block (no events and wait)
-	b0 := createEVMBlockFn(lastFinalizedBlock)
+	b0 := createEVMBlockFn(lastFinalizedBlock, true)
 	expectedBlocks = append(expectedBlocks, b0)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(1)).
@@ -236,7 +237,7 @@ func TestDownload(t *testing.T) {
 
 	// iteration 1: we have a new block, so increase to block (no events)
 	lastFinalizedBlock = &types.Header{Number: big.NewInt(2)}
-	b2 := createEVMBlockFn(lastFinalizedBlock)
+	b2 := createEVMBlockFn(lastFinalizedBlock, true)
 	expectedBlocks = append(expectedBlocks, b2)
 	d.On("WaitForNewBlocks", mock.Anything, uint64(1)).
 		Return(uint64(2))
@@ -252,14 +253,14 @@ func TestDownload(t *testing.T) {
 
 	// iteration 3: blocks 6 and 7 have events, last finalized block is 5
 	lastFinalizedBlock = &types.Header{Number: big.NewInt(5)}
-	b6 := EVMBlock{
+	b6 := &EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  6,
 			Hash: common.HexToHash("06"),
 		},
 		Events: []interface{}{"06"},
 	}
-	b7 := EVMBlock{
+	b7 := &EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  7,
 			Hash: common.HexToHash("07"),
@@ -273,7 +274,7 @@ func TestDownload(t *testing.T) {
 
 	// iteration 4: finalized block is now block 8, report the finalized block
 	lastFinalizedBlock = &types.Header{Number: big.NewInt(8)}
-	b8 := createEVMBlockFn(lastFinalizedBlock)
+	b8 := createEVMBlockFn(lastFinalizedBlock, true)
 	expectedBlocks = append(expectedBlocks, b8)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(8), uint64(8)).
@@ -297,12 +298,12 @@ func TestDownload(t *testing.T) {
 	d.On("WaitForNewBlocks", mock.Anything, uint64(19)).
 		After(time.Millisecond * 100).
 		Return(uint64(20)).Once()
-	b19 := createEVMBlockFn(&types.Header{Number: big.NewInt(19)})
+	b19 := createEVMBlockFn(&types.Header{Number: big.NewInt(19)}, true)
 	expectedBlocks = append(expectedBlocks, b19)
 	d.On("GetBlockHeader", mock.Anything, uint64(19)).Return(b19.EVMBlockHeader, false) // reporting empty finalized to block
 
 	// iteration 8: last finalized block is 21, no events
-	b20 := createEVMBlockFn(&types.Header{Number: big.NewInt(20)})
+	b20 := createEVMBlockFn(&types.Header{Number: big.NewInt(20)}, true)
 	expectedBlocks = append(expectedBlocks, b20)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(21)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(20)).
@@ -313,7 +314,7 @@ func TestDownload(t *testing.T) {
 	d.On("WaitForNewBlocks", mock.Anything, uint64(20)).
 		After(time.Millisecond * 100).
 		Return(uint64(21)).Once()
-	b21 := createEVMBlockFn(&types.Header{Number: big.NewInt(21)})
+	b21 := createEVMBlockFn(&types.Header{Number: big.NewInt(21)}, true)
 	expectedBlocks = append(expectedBlocks, b21)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(22)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(21), uint64(21)).
@@ -324,7 +325,7 @@ func TestDownload(t *testing.T) {
 	d.On("WaitForNewBlocks", mock.Anything, uint64(21)).
 		After(time.Millisecond * 100).
 		Return(uint64(22)).Once()
-	b22 := createEVMBlockFn(&types.Header{Number: big.NewInt(22)})
+	b22 := createEVMBlockFn(&types.Header{Number: big.NewInt(22)}, true)
 	expectedBlocks = append(expectedBlocks, b22)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(23)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(22), uint64(22)).
@@ -335,7 +336,7 @@ func TestDownload(t *testing.T) {
 	d.On("WaitForNewBlocks", mock.Anything, uint64(22)).
 		After(time.Millisecond * 100).
 		Return(uint64(23)).Once()
-	b23 := createEVMBlockFn(&types.Header{Number: big.NewInt(23)})
+	b23 := createEVMBlockFn(&types.Header{Number: big.NewInt(23)}, true)
 	expectedBlocks = append(expectedBlocks, b23)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(23)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(23), uint64(23)).
@@ -346,7 +347,7 @@ func TestDownload(t *testing.T) {
 	d.On("WaitForNewBlocks", mock.Anything, uint64(23)).
 		After(time.Millisecond * 100).
 		Return(uint64(24)).Once()
-	b24 := EVMBlock{
+	b24 := &EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  24,
 			Hash: common.HexToHash("24"),
@@ -365,7 +366,7 @@ func TestDownload(t *testing.T) {
 	for _, expectedBlock := range expectedBlocks {
 		actualBlock := <-downloadCh
 		log.Debugf("block %d received!", actualBlock.Num)
-		require.Equal(t, expectedBlock, actualBlock)
+		require.Equal(t, *expectedBlock, actualBlock)
 	}
 	log.Debug("canceling")
 	cancel()

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -216,7 +216,7 @@ func TestDownload(t *testing.T) {
 	lastFinalizedBlock := &types.Header{Number: big.NewInt(1)}
 	createEVMBlockFn := func(header *types.Header, isSafeBlock bool) *EVMBlock {
 		return &EVMBlock{
-			IsSafeBlock: isSafeBlock,
+			IsFinalizedBlock: isSafeBlock,
 			EVMBlockHeader: EVMBlockHeader{
 				Num:        header.Number.Uint64(),
 				Hash:       header.Hash(),

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -213,35 +213,45 @@ func TestDownload(t *testing.T) {
 	d.On("WaitForNewBlocks", mock.Anything, uint64(0)).
 		Return(uint64(1))
 
+	lastFinalizedBlock := &types.Header{Number: big.NewInt(1)}
+	createEVMBlockFn := func(header *types.Header) EVMBlock {
+		return EVMBlock{
+			EVMBlockHeader: EVMBlockHeader{
+				Num:        header.Number.Uint64(),
+				Hash:       header.Hash(),
+				ParentHash: header.ParentHash,
+				Timestamp:  header.Time,
+			},
+		}
+	}
+
 	// iteration 0:
 	// last block is 1, download that block (no events and wait)
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(1)}, nil).Once()
+	b0 := createEVMBlockFn(lastFinalizedBlock)
+	expectedBlocks = append(expectedBlocks, b0)
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(1)).
 		Return(EVMBlocks{}, false).Once()
+	d.On("GetBlockHeader", mock.Anything, uint64(1)).Return(b0.EVMBlockHeader, false).Once()
 
-	// iteration 1: we have a new block, so increase to block
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(2)}, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(1)).
-		Return(EVMBlocks{}, false).Once()
-
-	// iteration 2: block 2 has events
-	b2 := EVMBlock{
-		EVMBlockHeader: EVMBlockHeader{
-			Num:  2,
-			Hash: common.HexToHash("02"),
-		},
-	}
+	// iteration 1: we have a new block, so increase to block (no events)
+	lastFinalizedBlock = &types.Header{Number: big.NewInt(2)}
+	b2 := createEVMBlockFn(lastFinalizedBlock)
 	expectedBlocks = append(expectedBlocks, b2)
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(2)}, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(0), uint64(2)).
-		Return(EVMBlocks{b2}, false).Once()
+	d.On("WaitForNewBlocks", mock.Anything, uint64(1)).
+		Return(uint64(2))
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(2), uint64(2)).
+		Return(EVMBlocks{}, false).Once()
+	d.On("GetBlockHeader", mock.Anything, uint64(2)).Return(b2.EVMBlockHeader, false).Once()
 
-	// iteration 3: wait for next block to be created (jump to block 8)
+	// iteration 2: wait for next block to be created (jump to block 8)
 	d.On("WaitForNewBlocks", mock.Anything, uint64(2)).
 		After(time.Millisecond * 100).
 		Return(uint64(8)).Once()
 
-	// iteration 4: blocks 6 and 7 have events, but last finalized block is 5
+	// iteration 3: blocks 6 and 7 have events, but last finalized block is 5
+	lastFinalizedBlock = &types.Header{Number: big.NewInt(5)}
 	b6 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  6,
@@ -257,58 +267,85 @@ func TestDownload(t *testing.T) {
 		Events: []interface{}{"07"},
 	}
 	expectedBlocks = append(expectedBlocks, b6, b7)
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(5)}, nil).Once()
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(3), uint64(8)).
 		Return(EVMBlocks{b6, b7}, false)
 
-	// iteration 5: finalized block is now block 8, we report events b6 and b7
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(8)}, nil).Once()
+	// iteration 4: finalized block is now block 8, we report events b6 and b7
+	lastFinalizedBlock = &types.Header{Number: big.NewInt(8)}
+	b8 := createEVMBlockFn(lastFinalizedBlock)
+	expectedBlocks = append(expectedBlocks, b8)
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(3), uint64(8)).
 		Return(EVMBlocks{b6, b7}, false)
+	d.On("GetBlockHeader", mock.Anything, uint64(8)).Return(b8.EVMBlockHeader, false).Once()
 
-	// iteration 6: from block 9 to 19, no events
+	// iteration 5: from block 9 to 19, no events
+	lastFinalizedBlock = &types.Header{Number: big.NewInt(15)}
 	d.On("WaitForNewBlocks", mock.Anything, uint64(8)).
 		After(time.Millisecond * 100).
 		Return(uint64(19)).Once()
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(15)}, nil).Once()
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(19)).
 		Return(EVMBlocks{}, false)
 
-	// iteration 7: last finalized block is now 20, no events, report empty block
+	// iteration 6: last finalized block is now 20, no events, report empty block
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(20)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(9), uint64(19)).
 		Return(EVMBlocks{}, false)
 
-	b20 := EVMBlock{
-		EVMBlockHeader: EVMBlockHeader{
-			Num:  20,
-			Hash: common.HexToHash("20"),
-		},
-	}
-	expectedBlocks = append(expectedBlocks, b20)
-	d.On("GetBlockHeader", mock.Anything, uint64(20)).Return(b20.EVMBlockHeader, false) // reporting empty finalized block
+	d.On("WaitForNewBlocks", mock.Anything, uint64(19)).
+		After(time.Millisecond * 100).
+		Return(uint64(20)).Once()
+	b19 := createEVMBlockFn(&types.Header{Number: big.NewInt(19)})
+	expectedBlocks = append(expectedBlocks, b19)
+	d.On("GetBlockHeader", mock.Anything, uint64(19)).Return(b19.EVMBlockHeader, false) // reporting empty finalized to block
 
 	// iteration 8: last finalized block is 21, no events
+	b20 := createEVMBlockFn(&types.Header{Number: big.NewInt(20)})
+	expectedBlocks = append(expectedBlocks, b20)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(21)}, nil).Once()
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(20)).
 		Return(EVMBlocks{}, false)
+	d.On("GetBlockHeader", mock.Anything, uint64(20)).Return(b20.EVMBlockHeader, false) // reporting empty finalized to block
 
 	// iteration 9: last finalized block is 22, no events
+	d.On("WaitForNewBlocks", mock.Anything, uint64(20)).
+		After(time.Millisecond * 100).
+		Return(uint64(21)).Once()
+	b21 := createEVMBlockFn(&types.Header{Number: big.NewInt(21)})
+	expectedBlocks = append(expectedBlocks, b21)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(22)}, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(21)).
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(21), uint64(21)).
 		Return(EVMBlocks{}, false)
+	d.On("GetBlockHeader", mock.Anything, uint64(21)).Return(b21.EVMBlockHeader, false) // reporting empty finalized to block
 
 	// iteration 10: last finalized block is 23, no events
+	d.On("WaitForNewBlocks", mock.Anything, uint64(21)).
+		After(time.Millisecond * 100).
+		Return(uint64(22)).Once()
+	b22 := createEVMBlockFn(&types.Header{Number: big.NewInt(22)})
+	expectedBlocks = append(expectedBlocks, b22)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(23)}, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(22)).
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(22), uint64(22)).
 		Return(EVMBlocks{}, false)
+	d.On("GetBlockHeader", mock.Anything, uint64(22)).Return(b22.EVMBlockHeader, false) // reporting empty finalized to block
 
 	// iteration 11: last finalized block is still 23, no events
+	d.On("WaitForNewBlocks", mock.Anything, uint64(22)).
+		After(time.Millisecond * 100).
+		Return(uint64(23)).Once()
+	b23 := createEVMBlockFn(&types.Header{Number: big.NewInt(23)})
+	expectedBlocks = append(expectedBlocks, b23)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(23)}, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(23)).
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(23), uint64(23)).
 		Return(EVMBlocks{}, false)
+	d.On("GetBlockHeader", mock.Anything, uint64(23)).Return(b23.EVMBlockHeader, false) // reporting empty finalized to block
 
 	// iteration 12: finalized block is 24, has events
+	d.On("WaitForNewBlocks", mock.Anything, uint64(23)).
+		After(time.Millisecond * 100).
+		Return(uint64(24)).Once()
 	b24 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
 			Num:  24,
@@ -317,8 +354,8 @@ func TestDownload(t *testing.T) {
 		Events: []interface{}{testEvent(common.HexToHash("24"))},
 	}
 	expectedBlocks = append(expectedBlocks, b24)
-	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(24)}, nil).Twice()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(20), uint64(24)).
+	d.On("GetLastFinalizedBlock", mock.Anything).Return(&types.Header{Number: big.NewInt(24)}, nil).Once()
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(24), uint64(24)).
 		Return(EVMBlocks{b24}, false)
 
 	// iteration 13: closing the downloader

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -507,7 +507,7 @@ func NewTestDownloader(t *testing.T, retryPeriod time.Duration) (*EVMDownloader,
 	d, err := NewEVMDownloader("test",
 		clientMock, syncBlockChunck, etherman.LatestBlock, time.Millisecond,
 		buildAppender(), []common.Address{contractAddr}, rh,
-		etherman.SafeBlock,
+		etherman.FinalizedBlock,
 	)
 	require.NoError(t, err)
 	return d, clientMock

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -250,7 +250,7 @@ func TestDownload(t *testing.T) {
 		After(time.Millisecond * 100).
 		Return(uint64(8)).Once()
 
-	// iteration 3: blocks 6 and 7 have events, but last finalized block is 5
+	// iteration 3: blocks 6 and 7 have events, last finalized block is 5
 	lastFinalizedBlock = &types.Header{Number: big.NewInt(5)}
 	b6 := EVMBlock{
 		EVMBlockHeader: EVMBlockHeader{
@@ -271,13 +271,13 @@ func TestDownload(t *testing.T) {
 	d.On("GetEventsByBlockRange", mock.Anything, uint64(3), uint64(8)).
 		Return(EVMBlocks{b6, b7}, false)
 
-	// iteration 4: finalized block is now block 8, we report events b6 and b7
+	// iteration 4: finalized block is now block 8, report the finalized block
 	lastFinalizedBlock = &types.Header{Number: big.NewInt(8)}
 	b8 := createEVMBlockFn(lastFinalizedBlock)
 	expectedBlocks = append(expectedBlocks, b8)
 	d.On("GetLastFinalizedBlock", mock.Anything).Return(lastFinalizedBlock, nil).Once()
-	d.On("GetEventsByBlockRange", mock.Anything, uint64(3), uint64(8)).
-		Return(EVMBlocks{b6, b7}, false)
+	d.On("GetEventsByBlockRange", mock.Anything, uint64(8), uint64(8)).
+		Return(EVMBlocks{}, false)
 	d.On("GetBlockHeader", mock.Anything, uint64(8)).Return(b8.EVMBlockHeader, false).Once()
 
 	// iteration 5: from block 9 to 19, no events

--- a/sync/evmdownloader_test.go
+++ b/sync/evmdownloader_test.go
@@ -503,7 +503,11 @@ func NewTestDownloader(t *testing.T, retryPeriod time.Duration) (*EVMDownloader,
 		RetryAfterErrorPeriod:      retryPeriod,
 	}
 	clientMock := NewL2Mock(t)
-	d, err := NewEVMDownloader("test", clientMock, syncBlockChunck, etherman.LatestBlock, time.Millisecond, buildAppender(), []common.Address{contractAddr}, rh)
+	d, err := NewEVMDownloader("test",
+		clientMock, syncBlockChunck, etherman.LatestBlock, time.Millisecond,
+		buildAppender(), []common.Address{contractAddr}, rh,
+		etherman.SafeBlock,
+	)
 	require.NoError(t, err)
 	return d, clientMock
 }

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -92,9 +92,13 @@ reset:
 			d.log.Info("sync stopped due to context done")
 			cancel()
 			return
-		case b := <-downloadCh:
+		case b, ok := <-downloadCh:
 			d.log.Debugf("handleNewBlock, blockNum: %d, blockHash: %s", b.Num, b.Hash)
-			d.handleNewBlock(ctx, cancel, b)
+			if ok {
+				// when channel is closing, it is sending an empty block with num = 0, and empty hash
+				// because it is not passing object by reference, but by value, so do not handle that since it is closing
+				d.handleNewBlock(ctx, cancel, b)
+			}
 		case firstReorgedBlock := <-d.reorgSub.ReorgedBlock:
 			d.log.Debug("handleReorg from block: ", firstReorgedBlock)
 			d.handleReorg(ctx, cancel, firstReorgedBlock)

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -9,11 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type evmDownloaderFull interface {
-	EVMDownloaderInterface
-	downloader
-}
-
 type downloader interface {
 	Download(ctx context.Context, fromBlock uint64, downloadedCh chan EVMBlock)
 }

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -117,7 +117,7 @@ func (d *EVMDriver) handleNewBlock(ctx context.Context, cancel context.CancelFun
 			d.log.Warnf("context canceled while adding block %d to tracker", b.Num)
 			return
 		default:
-			if !b.IsSafeBlock {
+			if !b.IsFinalizedBlock {
 				err := d.reorgDetector.AddBlockToTrack(ctx, d.reorgDetectorID, b.Num, b.Hash)
 				if err != nil {
 					attempts++

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -96,7 +96,7 @@ reset:
 			if ok {
 				// when channel is closing, it is sending an empty block with num = 0, and empty hash
 				// because it is not passing object by reference, but by value, so do not handle that since it is closing
-				d.log.Debugf("handleNewBlock, blockNum: %d, blockHash: %s", b.Num, b.Hash)
+				d.log.Infof("handleNewBlock, blockNum: %d, blockHash: %s", b.Num, b.Hash)
 				d.handleNewBlock(ctx, cancel, b)
 			}
 		case firstReorgedBlock := <-d.reorgSub.ReorgedBlock:

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -117,11 +117,15 @@ func (d *EVMDriver) handleNewBlock(ctx context.Context, cancel context.CancelFun
 			d.log.Warnf("context canceled while adding block %d to tracker", b.Num)
 			return
 		default:
-			err := d.reorgDetector.AddBlockToTrack(ctx, d.reorgDetectorID, b.Num, b.Hash)
-			if err != nil {
-				attempts++
-				d.log.Errorf("error adding block %d to tracker: %v", b.Num, err)
-				d.rh.Handle("handleNewBlock", attempts)
+			if !b.IsSafeBlock {
+				err := d.reorgDetector.AddBlockToTrack(ctx, d.reorgDetectorID, b.Num, b.Hash)
+				if err != nil {
+					attempts++
+					d.log.Errorf("error adding block %d to tracker: %v", b.Num, err)
+					d.rh.Handle("handleNewBlock", attempts)
+				} else {
+					succeed = true
+				}
 			} else {
 				succeed = true
 			}

--- a/sync/evmdriver.go
+++ b/sync/evmdriver.go
@@ -93,10 +93,10 @@ reset:
 			cancel()
 			return
 		case b, ok := <-downloadCh:
-			d.log.Debugf("handleNewBlock, blockNum: %d, blockHash: %s", b.Num, b.Hash)
 			if ok {
 				// when channel is closing, it is sending an empty block with num = 0, and empty hash
 				// because it is not passing object by reference, but by value, so do not handle that since it is closing
+				d.log.Debugf("handleNewBlock, blockNum: %d, blockHash: %s", b.Num, b.Hash)
 				d.handleNewBlock(ctx, cancel, b)
 			}
 		case firstReorgedBlock := <-d.reorgSub.ReorgedBlock:

--- a/sync/evmtypes.go
+++ b/sync/evmtypes.go
@@ -2,6 +2,22 @@ package sync
 
 import "github.com/ethereum/go-ethereum/common"
 
+type EVMBlocks []EVMBlock
+
+func (e EVMBlocks) Len() int {
+	return len(e)
+}
+
+func (e EVMBlocks) LastFinalizedBlock(lastFinalizedBlockOnNetwork uint64) (uint64, int, bool) {
+	for i := len(e) - 1; i >= 0; i-- {
+		if e[i].Num <= lastFinalizedBlockOnNetwork {
+			return e[i].Num, i, true
+		}
+	}
+
+	return 0, 0, false // no finalized block found
+}
+
 type EVMBlock struct {
 	EVMBlockHeader
 	Events []interface{}

--- a/sync/evmtypes.go
+++ b/sync/evmtypes.go
@@ -8,16 +8,6 @@ func (e EVMBlocks) Len() int {
 	return len(e)
 }
 
-func (e EVMBlocks) LastFinalizedBlock(lastFinalizedBlockOnNetwork uint64) (uint64, int, bool) {
-	for i := len(e) - 1; i >= 0; i-- {
-		if e[i].Num <= lastFinalizedBlockOnNetwork {
-			return e[i].Num, i, true
-		}
-	}
-
-	return 0, 0, false // no finalized block found
-}
-
 type EVMBlock struct {
 	EVMBlockHeader
 	Events []interface{}
@@ -28,4 +18,5 @@ type EVMBlockHeader struct {
 	Hash       common.Hash
 	ParentHash common.Hash
 	Timestamp  uint64
+	SafeBlock  bool
 }

--- a/sync/evmtypes.go
+++ b/sync/evmtypes.go
@@ -2,7 +2,7 @@ package sync
 
 import "github.com/ethereum/go-ethereum/common"
 
-type EVMBlocks []EVMBlock
+type EVMBlocks []*EVMBlock
 
 func (e EVMBlocks) Len() int {
 	return len(e)
@@ -10,7 +10,8 @@ func (e EVMBlocks) Len() int {
 
 type EVMBlock struct {
 	EVMBlockHeader
-	Events []interface{}
+	IsSafeBlock bool
+	Events      []interface{}
 }
 
 type EVMBlockHeader struct {

--- a/sync/evmtypes.go
+++ b/sync/evmtypes.go
@@ -10,8 +10,8 @@ func (e EVMBlocks) Len() int {
 
 type EVMBlock struct {
 	EVMBlockHeader
-	IsSafeBlock bool
-	Events      []interface{}
+	IsFinalizedBlock bool
+	Events           []interface{}
 }
 
 type EVMBlockHeader struct {
@@ -19,5 +19,4 @@ type EVMBlockHeader struct {
 	Hash       common.Hash
 	ParentHash common.Hash
 	Timestamp  uint64
-	SafeBlock  bool
 }

--- a/sync/mock_downloader_test.go
+++ b/sync/mock_downloader_test.go
@@ -115,53 +115,53 @@ func (_c *EVMDownloaderMock_GetBlockHeader_Call) RunAndReturn(run func(context.C
 }
 
 // GetEventsByBlockRange provides a mock function with given fields: ctx, fromBlock, toBlock
-func (_m *EVMDownloaderMock) GetEventsByBlockRange(ctx context.Context, fromBlock uint64, toBlock uint64) []EVMBlock {
+func (_m *EVMDownloaderMock) GetEventsByBlockRange(ctx context.Context, fromBlock uint64, toBlock uint64) EVMBlocks {
 	ret := _m.Called(ctx, fromBlock, toBlock)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetEventsByBlockRange")
 	}
 
-	var r0 []EVMBlock
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) []EVMBlock); ok {
+	var r0 EVMBlocks
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) EVMBlocks); ok {
 		r0 = rf(ctx, fromBlock, toBlock)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]EVMBlock)
+			r0 = ret.Get(0).(EVMBlocks)
 		}
 	}
 
 	return r0
 }
 
-// EVMDownloaderMock_GetEventsByBlockRange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEventsByBlockRange'
-type EVMDownloaderMock_GetEventsByBlockRange_Call struct {
-	*mock.Call
-}
+// GetLastFinalizedBlock provides a mock function with given fields: ctx
+func (_m *EVMDownloaderMock) GetLastFinalizedBlock(ctx context.Context) (*types.Header, error) {
+	ret := _m.Called(ctx)
 
-// GetEventsByBlockRange is a helper method to define mock.On call
-//   - ctx context.Context
-//   - fromBlock uint64
-//   - toBlock uint64
-func (_e *EVMDownloaderMock_Expecter) GetEventsByBlockRange(ctx interface{}, fromBlock interface{}, toBlock interface{}) *EVMDownloaderMock_GetEventsByBlockRange_Call {
-	return &EVMDownloaderMock_GetEventsByBlockRange_Call{Call: _e.mock.On("GetEventsByBlockRange", ctx, fromBlock, toBlock)}
-}
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastFinalizedBlock")
+	}
 
-func (_c *EVMDownloaderMock_GetEventsByBlockRange_Call) Run(run func(ctx context.Context, fromBlock uint64, toBlock uint64)) *EVMDownloaderMock_GetEventsByBlockRange_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].(uint64))
-	})
-	return _c
-}
+	var r0 *types.Header
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*types.Header, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *types.Header); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.Header)
+		}
+	}
 
-func (_c *EVMDownloaderMock_GetEventsByBlockRange_Call) Return(_a0 []EVMBlock) *EVMDownloaderMock_GetEventsByBlockRange_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
 
-func (_c *EVMDownloaderMock_GetEventsByBlockRange_Call) RunAndReturn(run func(context.Context, uint64, uint64) []EVMBlock) *EVMDownloaderMock_GetEventsByBlockRange_Call {
-	_c.Call.Return(run)
-	return _c
+	return r0, r1
 }
 
 // GetLogs provides a mock function with given fields: ctx, fromBlock, toBlock

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -107,7 +107,7 @@ func L1Setup(t *testing.T) *L1Environment {
 	dbPathReorgDetectorL1 := path.Join(t.TempDir(), "ReorgDetectorL1.sqlite")
 	rdL1, err := reorgdetector.New(l1Client.Client(), reorgdetector.Config{
 		DBPath:              dbPathReorgDetectorL1,
-		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100},
+		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}, //nolint:mnd
 	})
 	require.NoError(t, err)
 	go rdL1.Start(ctx) //nolint:errcheck
@@ -184,7 +184,7 @@ func L2Setup(t *testing.T) *L2Environment {
 	dbPathReorgL2 := path.Join(t.TempDir(), "ReorgDetectorL2.sqlite")
 	rdL2, err := reorgdetector.New(l2Client.Client(), reorgdetector.Config{
 		DBPath:              dbPathReorgL2,
-		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}})
+		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}}) //nolint:mnd
 	require.NoError(t, err)
 	go rdL2.Start(ctx) //nolint:errcheck
 

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0xPolygon/cdk/aggoracle"
 	"github.com/0xPolygon/cdk/aggoracle/chaingersender"
 	"github.com/0xPolygon/cdk/bridgesync"
+	cfgTypes "github.com/0xPolygon/cdk/config/types"
 	"github.com/0xPolygon/cdk/etherman"
 	"github.com/0xPolygon/cdk/l1infotreesync"
 	"github.com/0xPolygon/cdk/log"
@@ -104,7 +105,10 @@ func L1Setup(t *testing.T) *L1Environment {
 
 	// Reorg detector
 	dbPathReorgDetectorL1 := path.Join(t.TempDir(), "ReorgDetectorL1.sqlite")
-	rdL1, err := reorgdetector.New(l1Client.Client(), reorgdetector.Config{DBPath: dbPathReorgDetectorL1})
+	rdL1, err := reorgdetector.New(l1Client.Client(), reorgdetector.Config{
+		DBPath:              dbPathReorgDetectorL1,
+		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100},
+	})
 	require.NoError(t, err)
 	go rdL1.Start(ctx) //nolint:errcheck
 
@@ -178,7 +182,9 @@ func L2Setup(t *testing.T) *L2Environment {
 
 	// Reorg detector
 	dbPathReorgL2 := path.Join(t.TempDir(), "ReorgDetectorL2.sqlite")
-	rdL2, err := reorgdetector.New(l2Client.Client(), reorgdetector.Config{DBPath: dbPathReorgL2})
+	rdL2, err := reorgdetector.New(l2Client.Client(), reorgdetector.Config{
+		DBPath:              dbPathReorgL2,
+		CheckReorgsInterval: cfgTypes.Duration{Duration: time.Millisecond * 100}})
 	require.NoError(t, err)
 	go rdL2.Start(ctx) //nolint:errcheck
 

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -128,7 +128,7 @@ func L1Setup(t *testing.T) *L1Environment {
 		originNetwork          = 1
 		initialBlock           = 0
 		retryPeriod            = 0
-		retriesCount           = 0
+		retriesCount           = 10
 	)
 
 	// Bridge sync

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -117,6 +117,7 @@ func L1Setup(t *testing.T) *L1Environment {
 		rdL1, l1Client.Client(),
 		time.Millisecond, 0, periodRetry,
 		retries, l1infotreesync.FlagAllowWrongContractsAddrs,
+		etherman.SafeBlock,
 	)
 	require.NoError(t, err)
 
@@ -138,7 +139,7 @@ func L1Setup(t *testing.T) *L1Environment {
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
 		syncBlockChunks, etherman.LatestBlock, rdL1, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false)
+		retriesCount, originNetwork, false, etherman.SafeBlock)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -198,7 +199,7 @@ func L2Setup(t *testing.T) *L2Environment {
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunks,
 		etherman.LatestBlock, rdL2, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false)
+		retriesCount, originNetwork, false, etherman.LatestBlock)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)

--- a/test/helpers/wait.go
+++ b/test/helpers/wait.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -19,14 +19,18 @@ func RequireProcessorUpdated(t *testing.T, processor Processorer, targetBlock ui
 		maxIterations         = 100
 		sleepTimePerIteration = time.Millisecond * 10
 	)
+	var (
+		lpb uint64
+		err error
+	)
 	ctx := context.Background()
 	for i := 0; i < maxIterations; i++ {
-		lpb, err := processor.GetLastProcessedBlock(ctx)
+		lpb, err = processor.GetLastProcessedBlock(ctx)
 		require.NoError(t, err)
 		if targetBlock <= lpb {
 			return
 		}
 		time.Sleep(sleepTimePerIteration)
 	}
-	require.NoError(t, errors.New("processor not updated"))
+	require.NoError(t, fmt.Errorf("processor not updated. Last block: %d, target block: %d", lpb, targetBlock))
 }


### PR DESCRIPTION
## Description

This PR fixes the issues found on the `l1infotreesyncer` and `reorg detector`, when we might not be tracking a correct block hash in the `reorg detector`.

It also fixes an issue when download channel is closing, it passes an empty block object (since it is passing objects by value and not by reference), with number 0, and empty hash, which processor passes to the `reorg detector` which is not correct.

**Important Note**:
`e2e` tests use `sumulated client` as the `l1 client` node, which only knows of `SafeBlocks`. That is why this PR expanded the constructor function of the `EVMDownloader` to receive `finalizedBlockType` parameter. When we run the `cdk` node or any syncer that syncs data from `L1`, the `finalizedBlockType` is `FinalizedBlock` as seen in the `run.go`. `e2e` tests use `SafeBlock`.
Also, `L2` does not have a notion of `FinalizedBlock`, so `bridgeL2Syncer` will use the `LatestBlock` for this parameter.

Fixes # (issue)
