### PR TITLE
fix: case of eth_getBlockByHash response null or tstamp zero

### DIFF
--- a/rpc/batch.go
+++ b/rpc/batch.go
@@ -116,7 +116,7 @@ func (b *BatchEndpoints) GetL2BlockTimestamp(blockHash string) (uint64, error) {
 	}
 	timestamp := new(big.Int).SetBytes(common.FromHex(l2Block.Timestamp)).Uint64()
 	if timestamp == 0 {
-		return 0, fmt.Errorf("error timestamp str:'%s' form Block hash: %s is 0", l2Block.Timestamp, blockHash)
+		return 0, fmt.Errorf("timestamp str '%s' from block hash %s is 0", l2Block.Timestamp, blockHash)
 	}
 	return timestamp, nil
 }

--- a/rpc/batch.go
+++ b/rpc/batch.go
@@ -104,7 +104,7 @@ func (b *BatchEndpoints) GetL2BlockTimestamp(blockHash string) (uint64, error) {
 	}
 
 	if string(response.Result) == "null" {
-		log.Errorf("error response of eth_getBlockByHash  is null. Block hash: %s. err: Not Found", blockHash)
+		log.Errorf("eth_getBlockByHash response is null. Block hash %s not found", blockHash)
 		return 0, fmt.Errorf("error response of eth_getBlockByHash  is null. Block hash: %s. err: Not Found", blockHash)
 	}
 

--- a/rpc/batch.go
+++ b/rpc/batch.go
@@ -15,7 +15,8 @@ import (
 
 var (
 	// ErrBusy is returned when the witness server is busy
-	ErrBusy = errors.New("witness server is busy")
+	ErrBusy     = errors.New("witness server is busy")
+	jSONRPCCall = rpc.JSONRPCCall
 )
 
 const busyResponse = "busy"
@@ -92,7 +93,7 @@ func (b *BatchEndpoints) GetL2BlockTimestamp(blockHash string) (uint64, error) {
 
 	log.Infof("Getting l2 block timestamp from RPC. Block hash: %s", blockHash)
 
-	response, err := rpc.JSONRPCCall(b.url, "eth_getBlockByHash", blockHash, false)
+	response, err := jSONRPCCall(b.url, "eth_getBlockByHash", blockHash, false)
 	if err != nil {
 		return 0, err
 	}
@@ -102,14 +103,22 @@ func (b *BatchEndpoints) GetL2BlockTimestamp(blockHash string) (uint64, error) {
 		return 0, fmt.Errorf("error in the response calling eth_getBlockByHash: %v", response.Error)
 	}
 
+	if string(response.Result) == "null" {
+		log.Errorf("error response of eth_getBlockByHash  is null. Block hash: %s. err: Not Found", blockHash)
+		return 0, fmt.Errorf("error response of eth_getBlockByHash  is null. Block hash: %s. err: Not Found", blockHash)
+	}
+
 	//  Get the l2 block from the response
 	l2Block := zkeEVML2Block{}
 	err = json.Unmarshal(response.Result, &l2Block)
 	if err != nil {
 		return 0, fmt.Errorf("error unmarshalling the l2 block from the response calling eth_getBlockByHash: %w", err)
 	}
-
-	return new(big.Int).SetBytes(common.FromHex(l2Block.Timestamp)).Uint64(), nil
+	timestamp := new(big.Int).SetBytes(common.FromHex(l2Block.Timestamp)).Uint64()
+	if timestamp == 0 {
+		return 0, fmt.Errorf("error timestamp str:'%s' form Block hash: %s is 0", l2Block.Timestamp, blockHash)
+	}
+	return timestamp, nil
 }
 
 func (b *BatchEndpoints) GetWitness(batchNumber uint64, fullWitness bool) ([]byte, error) {

--- a/rpc/batch_test.go
+++ b/rpc/batch_test.go
@@ -74,8 +74,6 @@ func Test_getBatchFromRPC(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req rpc.Request
 				err := json.NewDecoder(r.Body).Decode(&req)
@@ -228,8 +226,6 @@ func Test_getGetL2BlockTimestamp(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req rpc.Request
 				err := json.NewDecoder(r.Body).Decode(&req)

--- a/rpc/batch_test.go
+++ b/rpc/batch_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func Test_getBatchFromRPC(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name                 string
 		batch                uint64
@@ -200,8 +198,6 @@ func Test_getBatchWitnessRPC(t *testing.T) {
 }
 
 func Test_getGetL2BlockTimestamp(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name       string
 		blockHash  []byte

--- a/rpc/batch_test.go
+++ b/rpc/batch_test.go
@@ -263,3 +263,31 @@ func Test_getGetL2BlockTimestamp(t *testing.T) {
 		})
 	}
 }
+
+func Test_getGetL2BlockTimestampNull(t *testing.T) {
+	response := rpc.Response{
+		Result: []byte(`null`),
+	}
+	jSONRPCCall = func(_, _ string, _ ...interface{}) (rpc.Response, error) {
+		return response, nil
+	}
+	sut := NewBatchEndpoints("http://localhost:8080")
+	timestamp, err := sut.GetL2BlockTimestamp("0x123456")
+	require.Error(t, err)
+	require.Equal(t, uint64(0), timestamp)
+	require.Contains(t, err.Error(), "error response of eth_getBlockByHash  is null. Block hash: 0x123456. err: Not Found")
+}
+
+func Test_getGetL2BlockTimestampZero(t *testing.T) {
+	response := rpc.Response{
+		Result: []byte(`{"timestamp": "0x0"}`),
+	}
+	jSONRPCCall = func(_, _ string, _ ...interface{}) (rpc.Response, error) {
+		return response, nil
+	}
+	sut := NewBatchEndpoints("http://localhost:8080")
+	timestamp, err := sut.GetL2BlockTimestamp("0x123456")
+	require.Error(t, err)
+	require.Equal(t, uint64(0), timestamp)
+	require.Contains(t, err.Error(), "is 0")
+}

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -4,7 +4,7 @@ args:
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   data_availability_mode: rollup
   sequencer_type: erigon
   

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
+  zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -3,7 +3,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   data_availability_mode: cdk-validium
   sequencer_type: erigon
   

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -3,6 +3,6 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   data_availability_mode: rollup
   sequencer_type: erigon

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   cdk_node_image: cdk

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -5,7 +5,7 @@ args:
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   cdk_node_image: cdk
-  zkevm_use_gas_token_contract: true
+  gas_token_enabled: true
   additional_services:
     - pless_zkevm_node
   data_availability_mode: cdk-validium

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -1,5 +1,5 @@
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
+  zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1


### PR DESCRIPTION
## Description

If RPC returns a `null` to the call `eth_getBlockByHash` then it get a tstamp of zero that produce a incorrect value for `maxSequenceTimestamp`


