### PR TITLE
feat: add Dependabot configuration for gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Description

This PR adds Dependabot configuration, in order to create the PRs against the `develop` branch.

Fixes # (issue)
