### PR TITLE
fix: golangci-lint and bump the versions of the golangci-lint 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
+
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.61
+          version: v1.64.5
           args: --timeout=30m

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Test
         run: make test-unit
           
-      - name: Analyze with SonarCloud
-        uses: sonarsource/sonarcloud-github-action@master
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,16 +3,11 @@
 run:
   timeout: 3m
   tests: true
-  skip-dirs-use-default: true
-
-service:
-  golangci-lint-version: 1.61.0
     
 linters:
   disable-all: true
   enable:
     - whitespace # Tool for detection of leading and trailing whitespace
-    # - wsl # Forces you to use empty lines
     - wastedassign # Finds wasted assignment statements
     - unconvert  # Unnecessary type conversions
     - tparallel # Detects inappropriate usage of t.Parallel() method in your Go test codes
@@ -21,7 +16,6 @@ linters:
     - prealloc # Finds slice declarations that could potentially be pre-allocated
     - predeclared # Finds code that shadows one of Go's predeclared identifiers
     - nolintlint # Ill-formed or insufficient nolint directives
-    # - nlreturn # Checks for a new line before return and branch statements to increase code clarity
     - misspell # Misspelled English words in comments
     - makezero # Finds slice declarations with non-zero initial length
     - lll # Long lines
@@ -40,7 +34,7 @@ linters:
     # - godox # Linter for TODOs and FIXMEs left in the code
     - gci # Gci checks the consistency of the code with the Go code style guide
     - mnd # mnd is a linter for magic numbers
-    # - revive 
+    # - revive
     - unparam # Unused function parameters
 
 linters-settings:


### PR DESCRIPTION
## Description

Fix the golangci-lint configuration (remove the obsolete fields) and bump the version of the golangci-lint version to v1.64.5 and golangci-lint-action to v6.5.0.

Fixes # (issue)
