### PR TITLE
fix: error related to returned errors from ethtxmanager library

### DIFF
--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  
   test-e2e-multi_pp:
     strategy:
       fail-fast: false

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: main
+        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref:  v0.3.2
+        ref: main
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref:  v0.2.31
+        ref:  v0.3.2
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.31
+        ref:  v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-pp.yml
+++ b/.github/workflows/test-e2e-pp.yml
@@ -1,4 +1,4 @@
-name: Test e2e
+name: Test e2e pp
 on: 
   push:
     branches:
@@ -38,10 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         e2e-group:
-          - "fork9-validium"
-          - "fork11-rollup"
-          - "fork12-validium"
-          - "fork12-rollup"
+          - "fork12-pessimistic"
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -51,7 +48,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.3.3
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.31
+        ref: v0.3.2
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.3.2
+        ref: v0.3.0
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.31
+        ref: main
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.3.0
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: main
+        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-resequence.yml
+++ b/.github/workflows/test-resequence.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: 0xPolygon/kurtosis-cdk
           path: kurtosis-cdk
-          ref: cb8e973dd11d030e06920822fec9c337be8c24f9
+          ref: v0.2.31
 
       - name: Install Kurtosis CDK tools
         uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-resequence.yml
+++ b/.github/workflows/test-resequence.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: 0xPolygon/kurtosis-cdk
           path: kurtosis-cdk
-          ref: v0.2.24
+          ref: cb8e973dd11d030e06920822fec9c337be8c24f9
 
       - name: Install Kurtosis CDK tools
         uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef
 	github.com/0xPolygon/cdk-data-availability v0.0.12
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
-	github.com/0xPolygon/zkevm-ethtx-manager v0.2.5
+	github.com/0xPolygon/zkevm-ethtx-manager v0.2.6
 	github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7
 	github.com/ethereum/go-ethereum v1.15.5
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/0xPolygon/cdk-contracts-tooling v0.0.2-0.20241225094934-1d381f5703ef
 	github.com/0xPolygon/cdk-data-availability v0.0.12
 	github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6
-	github.com/0xPolygon/zkevm-ethtx-manager v0.2.6
+	github.com/0xPolygon/zkevm-ethtx-manager v0.2.7
 	github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7
 	github.com/ethereum/go-ethereum v1.15.5
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/0xPolygon/cdk-data-availability v0.0.12 h1:nI3TnYpBHg/VhGQ9XGFSe1atWq
 github.com/0xPolygon/cdk-data-availability v0.0.12/go.mod h1:Qmi6eFHVBNp5nlWZHp2tc8ci/3Mb0IGVKA52lADTIz0=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6 h1:FXL/rcO7/GtZ3kRFw+C7J6vmGnl8gcazg+Gh/NVmnas=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.6 h1:36i/EHy1tZjkvQXQXPx3EMmXbGM399ga4ncA1qzw0Yg=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.6/go.mod h1:xuLx/9KDv5wO8mnkiiX5pZHyTWQZXyHjmBRBGEzNGXo=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.7 h1:eS2ewz4z+S16ZWQRyci6Y3U9YSR+sx1opB0/NxhmKlQ=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.7/go.mod h1:xuLx/9KDv5wO8mnkiiX5pZHyTWQZXyHjmBRBGEzNGXo=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7 h1:KJM1QlNZdZjNRS+ajPauD4uG+uaYgItaL+96Om3f8aI=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7/go.mod h1:exl+KHnTN6Y8HG4nSUXni4qKbAug0HjJqpebMSgl72k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/0xPolygon/cdk-data-availability v0.0.12 h1:nI3TnYpBHg/VhGQ9XGFSe1atWq
 github.com/0xPolygon/cdk-data-availability v0.0.12/go.mod h1:Qmi6eFHVBNp5nlWZHp2tc8ci/3Mb0IGVKA52lADTIz0=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6 h1:FXL/rcO7/GtZ3kRFw+C7J6vmGnl8gcazg+Gh/NVmnas=
 github.com/0xPolygon/cdk-rpc v0.0.0-20241004114257-6c3cb6eebfb6/go.mod h1:2scWqMMufrQXu7TikDgQ3BsyaKoX8qP26D6E262vSOg=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.5 h1:t6vLS597OjPcoZzvpGXooIy+ANQEX6LoxYBenRmu15I=
-github.com/0xPolygon/zkevm-ethtx-manager v0.2.5/go.mod h1:xuLx/9KDv5wO8mnkiiX5pZHyTWQZXyHjmBRBGEzNGXo=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.6 h1:36i/EHy1tZjkvQXQXPx3EMmXbGM399ga4ncA1qzw0Yg=
+github.com/0xPolygon/zkevm-ethtx-manager v0.2.6/go.mod h1:xuLx/9KDv5wO8mnkiiX5pZHyTWQZXyHjmBRBGEzNGXo=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7 h1:KJM1QlNZdZjNRS+ajPauD4uG+uaYgItaL+96Om3f8aI=
 github.com/0xPolygonHermez/zkevm-synchronizer-l1 v1.0.7/go.mod h1:exl+KHnTN6Y8HG4nSUXni4qKbAug0HjJqpebMSgl72k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/sequencesender/ethtx.go
+++ b/sequencesender/ethtx.go
@@ -13,10 +13,9 @@ import (
 
 	"github.com/0xPolygon/cdk/log"
 	"github.com/0xPolygon/zkevm-ethtx-manager/types"
+	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	"github.com/ethereum/go-ethereum/common"
 )
-
-const ErrTxNotFoundMessage = "not found"
 
 type ethTxData struct {
 	Nonce           uint64                              `json:"nonce"`
@@ -217,6 +216,9 @@ func (s *SequenceSender) syncAllEthTxResults(ctx context.Context) (time.Time, er
 	numResults := len(results)
 	s.mutexEthTx.Lock()
 	for _, result := range results {
+		for txHash, _ := range result.Txs {
+			log.Debugf("syncAllEthTxResults: id: %s tx:%s", result.ID.String(), txHash.String())
+		}
 		txSequence, exists := s.ethTransactions[result.ID]
 		if !exists {
 			log.Debugf("transaction %v missing in memory structure. Adding it", result.ID)
@@ -333,8 +335,14 @@ func isEthTxManagerErrNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	if err.Error() == ErrTxNotFoundMessage {
+	if errors.Is(err, ethtxmanager.ErrNotFound) {
 		return true
+	}
+	for err != nil {
+		if err.Error() == ethtxmanager.ErrNotFound.Error() {
+			return true
+		}
+		err = errors.Unwrap(err)
 	}
 	return false
 }

--- a/sequencesender/ethtx.go
+++ b/sequencesender/ethtx.go
@@ -12,10 +12,11 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk/log"
-	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	"github.com/0xPolygon/zkevm-ethtx-manager/types"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+const ErrTxNotFoundMessage = "not found"
 
 type ethTxData struct {
 	Nonce           uint64                              `json:"nonce"`
@@ -306,7 +307,8 @@ func (s *SequenceSender) getResultAndUpdateEthTx(ctx context.Context, txHash com
 
 	txResult, err := s.ethTxManager.Result(ctx, txHash)
 	switch {
-	case errors.Is(err, ethtxmanager.ErrNotFound):
+	//case errors.Is(err, ethtxmanager.ErrNotFound):
+	case isEthTxManagerErrNotFound(err):
 		s.logger.Infof("transaction %v does not exist in ethtxmanager. Marking it", txHash)
 		txData.OnMonitor = false
 		// Resend tx
@@ -324,6 +326,16 @@ func (s *SequenceSender) getResultAndUpdateEthTx(ctx context.Context, txHash com
 	}
 
 	return nil
+}
+
+func isEthTxManagerErrNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if err.Error() == ErrTxNotFoundMessage {
+		return true
+	}
+	return false
 }
 
 // loadSentSequencesTransactions loads the file into the memory structure

--- a/sequencesender/ethtx.go
+++ b/sequencesender/ethtx.go
@@ -307,7 +307,6 @@ func (s *SequenceSender) getResultAndUpdateEthTx(ctx context.Context, txHash com
 
 	txResult, err := s.ethTxManager.Result(ctx, txHash)
 	switch {
-	//case errors.Is(err, ethtxmanager.ErrNotFound):
 	case isEthTxManagerErrNotFound(err):
 		s.logger.Infof("transaction %v does not exist in ethtxmanager. Marking it", txHash)
 		txData.OnMonitor = false
@@ -328,6 +327,8 @@ func (s *SequenceSender) getResultAndUpdateEthTx(ctx context.Context, txHash com
 	return nil
 }
 
+// this function is use instead of
+// errors.Is(err, ethtxmanager.ErrNotFound)
 func isEthTxManagerErrNotFound(err error) bool {
 	if err == nil {
 		return false

--- a/sequencesender/ethtx.go
+++ b/sequencesender/ethtx.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk/log"
+	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	"github.com/0xPolygon/zkevm-ethtx-manager/types"
-	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -216,7 +216,7 @@ func (s *SequenceSender) syncAllEthTxResults(ctx context.Context) (time.Time, er
 	numResults := len(results)
 	s.mutexEthTx.Lock()
 	for _, result := range results {
-		for txHash, _ := range result.Txs {
+		for txHash := range result.Txs {
 			log.Debugf("syncAllEthTxResults: id: %s tx:%s", result.ID.String(), txHash.String())
 		}
 		txSequence, exists := s.ethTransactions[result.ID]
@@ -338,6 +338,7 @@ func isEthTxManagerErrNotFound(err error) bool {
 	if errors.Is(err, ethtxmanager.ErrNotFound) {
 		return true
 	}
+	// Check all wrapped errors looking for the same message
 	for err != nil {
 		if err.Error() == ethtxmanager.ErrNotFound.Error() {
 			return true

--- a/sequencesender/ethtx_test.go
+++ b/sequencesender/ethtx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"testing"
@@ -17,6 +18,14 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsEthTxManagerErrNotFound(t *testing.T) {
+	require.False(t, isEthTxManagerErrNotFound(nil))
+	require.True(t, isEthTxManagerErrNotFound(ethtxmanager.ErrNotFound))
+	require.True(t, isEthTxManagerErrNotFound(fmt.Errorf("not found")))
+	require.True(t, isEthTxManagerErrNotFound(fmt.Errorf("wrapper: %w", ethtxmanager.ErrNotFound)))
+	require.False(t, isEthTxManagerErrNotFound(errors.New("another error")))
+}
 
 func Test_sendTx(t *testing.T) {
 	t.Parallel()

--- a/sequencesender/ethtx_test.go
+++ b/sequencesender/ethtx_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/0xPolygon/cdk/log"
 	"github.com/0xPolygon/cdk/sequencesender/mocks"
-	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
@@ -661,7 +660,7 @@ func Test_getResultAndUpdateEthTx(t *testing.T) {
 				t.Helper()
 
 				mngr := mocks.NewEthTxManagerMock(t)
-				mngr.On("Result", mock.Anything, common.HexToHash("0x1")).Return(ethtxtypes.MonitoredTxResult{}, ethtxmanager.ErrNotFound)
+				mngr.On("Result", mock.Anything, common.HexToHash("0x1")).Return(ethtxtypes.MonitoredTxResult{}, errors.New(ErrTxNotFoundMessage))
 				mngr.On("AddWithGas", mock.Anything, mock.Anything, big.NewInt(0), mock.Anything, mock.Anything, mock.Anything, uint64(100500)).Return(common.Hash{}, nil)
 				mngr.On("Result", mock.Anything, common.Hash{}).Return(ethtxtypes.MonitoredTxResult{
 					ID:   common.HexToHash("0x1"),

--- a/sequencesender/ethtx_test.go
+++ b/sequencesender/ethtx_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0xPolygon/cdk/log"
 	"github.com/0xPolygon/cdk/sequencesender/mocks"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
+	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -660,7 +661,7 @@ func Test_getResultAndUpdateEthTx(t *testing.T) {
 				t.Helper()
 
 				mngr := mocks.NewEthTxManagerMock(t)
-				mngr.On("Result", mock.Anything, common.HexToHash("0x1")).Return(ethtxtypes.MonitoredTxResult{}, errors.New(ErrTxNotFoundMessage))
+				mngr.On("Result", mock.Anything, common.HexToHash("0x1")).Return(ethtxtypes.MonitoredTxResult{}, ethtxmanager.ErrNotFound)
 				mngr.On("AddWithGas", mock.Anything, mock.Anything, big.NewInt(0), mock.Anything, mock.Anything, mock.Anything, uint64(100500)).Return(common.Hash{}, nil)
 				mngr.On("Result", mock.Anything, common.Hash{}).Return(ethtxtypes.MonitoredTxResult{
 					ID:   common.HexToHash("0x1"),

--- a/sequencesender/ethtx_test.go
+++ b/sequencesender/ethtx_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/0xPolygon/cdk/log"
 	"github.com/0xPolygon/cdk/sequencesender/mocks"
+	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
-	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -173,7 +173,7 @@ func (s *SequenceSender) batchRetrieval(ctx context.Context) error {
 			// Try to retrieve batch from RPC
 			rpcBatch, err := s.rpcClient.GetBatch(currentBatchNumber)
 			if err != nil {
-				if errors.Is(err, ethtxmanager.ErrNotFound) {
+				if isEthTxManagerErrNotFound(err) {
 					s.logger.Infof("batch %d not found in RPC", currentBatchNumber)
 				} else {
 					s.logger.Errorf("error getting batch %d from RPC: %v", currentBatchNumber, err)

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -2,14 +2,12 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
-  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-hotfix.2-fork.11
+  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11
   cdk_node_image: cdk:latest
   gas_token_enabled: true
   gas_token_address: ""
   consensus_contract_type: rollup
   sequencer_type: erigon
-  # This is just a workaround, since the Kurtosis is deploying the agglayer even in the FEP setup
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -2,7 +2,7 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -2,7 +2,7 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
+  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -2,13 +2,10 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   cdk_node_image: cdk:latest
   gas_token_enabled: true
   gas_token_address: ""
   consensus_contract_type: cdk-validium
   sequencer_type: erigon
-  # This is just a workaround, since the Kurtosis is deploying the agglayer even in the FEP setup
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -25,7 +25,6 @@ args:
   zkevm_l2_proofsigner_address: "0xf1a661D7b601Ec46a040f57193cC99aB8c4132FA"
   zkevm_l2_proofsigner_private_key: "0xc7fe3a006d75ba9326d9792523385abb49057c66aee0b8b4248821a89713f975"
 
-
   cdk_node_image: cdk:latest
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
@@ -37,4 +36,3 @@ args:
   zkevm_use_real_verifier: false
   enable_normalcy: true
   verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
-

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,6 +1,6 @@
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:main
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,6 +1,6 @@
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,6 +1,6 @@
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,6 +1,6 @@
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
+  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,8 +1,9 @@
 args:
+  verbosity: debug
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-hotfix2
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
@@ -12,6 +13,3 @@ args:
   enable_normalcy: true
   verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
   agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}
-
-
-

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,5 +1,5 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   cdk_node_image: cdk:latest

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,5 +1,5 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   cdk_node_image: cdk:latest

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,5 +1,5 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:main
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   cdk_node_image: cdk:latest

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,5 +1,5 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
+  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   cdk_node_image: cdk:latest

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,18 +1,18 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  verbosity: debug
   cdk_node_image: cdk:latest
-  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC5
-  zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-hotfix2
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
   gas_token_enabled: true
-  gas_token_address: ""
+  gas_token_address: ''
   zkevm_use_real_verifier: false
+  agglayer_prover_primary_prover: mock-prover
   enable_normalcy: true
+  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}
   verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
-  

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -2,12 +2,10 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   cdk_node_image: cdk:latest
   gas_token_enabled: true
   gas_token_address: ""
   consensus_contract_type: rollup
   sequencer_type: erigon
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -2,7 +2,7 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
+  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -2,7 +2,7 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -2,10 +2,10 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.17
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
-  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
+  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   consensus_contract_type: cdk-validium
   cdk_node_image: cdk:latest
@@ -13,6 +13,3 @@ args:
   gas_token_address: ""
   additional_services:
     - pless_zkevm_node
-  sequencer_type: erigon
-  # This is just a workaround, since the Kurtosis is deploying the agglayer even in the FEP setup
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/config/kurtosis-cdk-node-config.toml.template.pessimistic
+++ b/test/config/kurtosis-cdk-node-config.toml.template.pessimistic
@@ -1,7 +1,7 @@
 PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-AggLayerURL="{{.agglayer_readrpc_url}}"
+AggLayerURL="{{.agglayer_url}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}
@@ -25,6 +25,8 @@ AggregatorPrivateKeyPassword  = "{{.zkevm_l2_keystore_password}}"
 SenderProofToL1Addr = "{{.zkevm_l2_agglayer_address}}"   
 polygonBridgeAddr = "{{.zkevm_bridge_address}}" 
 
+
+RPCURL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 WitnessURL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 
 

--- a/test/run-e2e-multi_pp.sh
+++ b/test/run-e2e-multi_pp.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source $(dirname $0)/scripts/env.sh
+source $(dirname $0)/scripts/shared.sh
 
 function log_error() {
     echo -e "\033[0;31mError: $*" "\033[0m"
@@ -43,6 +44,8 @@ function resolve_template(){
     eval $_RESULT_VARNAME="$_TEMP_FILE"
 }
 
+
+
 ###############################################################################
 # MAIN
 ###############################################################################
@@ -61,6 +64,9 @@ KURTOSIS_ENCLAVE=cdk
 build_docker_if_required
 resolve_template $PP1_ORIGIN_CONFIG_FILE PP1_RENDERED_CONFIG_FILE
 resolve_template $PP2_ORIGIN_CONFIG_FILE PP2_RENDERED_CONFIG_FILE
+
+override_cdk_node_config_file pessimistic
+ok_or_fatal "Failed to override cdk node config file"
 
 kurtosis clean --all
 kurtosis run --enclave $KURTOSIS_ENCLAVE --args-file "$PP1_RENDERED_CONFIG_FILE" --image-download always $KURTOSIS_FOLDER

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source $(dirname $0)/scripts/env.sh
+source $(dirname $0)/scripts/shared.sh
 
 FORK=$1
 if [ -z $FORK ]; then
@@ -25,8 +26,8 @@ else
 fi
 
 kurtosis clean --all
-echo "Override cdk config file"
-cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+override_cdk_node_config_file $DATA_AVAILABILITY_MODE
+
 KURTOSIS_CONFIG_FILE="combinations/$FORK-$DATA_AVAILABILITY_MODE.yml"
 TEMP_CONFIG_FILE=$(mktemp --suffix ".yml")
 echo "rendering $KURTOSIS_CONFIG_FILE to temp file $TEMP_CONFIG_FILE"

--- a/test/scripts/agglayer_certificates_monitor.sh
+++ b/test/scripts/agglayer_certificates_monitor.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # This script monitors the agglayer certificates progress of pessimistic proof.
 
-function parse_params(){
+function parse_params() {
     # Check if the required arguments are provided.
     if [ "$#" -lt 3 ]; then
-    echo "Usage: $0 <settle_certificates_target> <timeout> <l2_network_id>"
-    exit 1
+        echo "Usage: $0 <settle_certificates_target> <timeout> <l2_network_id>"
+        exit 1
     fi
 
     # The number of batches to be verified.
@@ -18,7 +18,7 @@ function parse_params(){
     l2_rpc_network_id="$3"
 }
 
-function check_timeout(){
+function check_timeout() {
     local _end_time=$1
     current_time=$(date +%s)
     if ((current_time > _end_time)); then
@@ -27,13 +27,19 @@ function check_timeout(){
     fi
 }
 
-function check_num_certificates(){
-    readonly agglayer_rpc_url="$(kurtosis port print cdk agglayer agglayer)"
+function check_num_certificates() {
+    agglayer_rpc_url="$(kurtosis port print cdk agglayer aglr-readrpc)"
+    if [ $? -ne 0 ]; then
+        agglayer_rpc_url="$(kurtosis port print cdk agglayer agglayer)"
+        if [ $? -ne 0 ]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] Error getting agglayer rpc url (not aglr-readrpc or agglayer)." >&3
+        fi
+    fi
 
     cast_output=$(cast rpc --rpc-url "$agglayer_rpc_url" "interop_getLatestKnownCertificateHeader" "$l2_rpc_network_id" 2>&1)
 
     if [ $? -ne 0 ]; then
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Error executing command cast rpc: $cast_output"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Error executing command cast rpc $agglayer_rpc_url: $cast_output"
         return
     fi
 
@@ -51,17 +57,17 @@ function check_num_certificates(){
 
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Last known agglayer certificate height: $height, status: $status" >&3
 
-    if (( height > settle_certificates_target - 1 )); then
+    if ((height > settle_certificates_target - 1)); then
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Success! The number of settled certificates has reached the target." >&3
         exit 0
     fi
 
-    if (( height == settle_certificates_target - 1 )); then
+    if ((height == settle_certificates_target - 1)); then
         if [ "$status" == "Settled" ]; then
             echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Success! The number of settled certificates has reached the target." >&3
             exit 0
         fi
-        
+
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] ⚠️ Warning! The number of settled certificates is one less than the target." >&3
     fi
 }
@@ -73,7 +79,7 @@ function extract_certificate_height() {
 
 function extract_certificate_status() {
     local cast_output="$1"
-     echo "$cast_output" | jq -r '.status'
+    echo "$cast_output" | jq -r '.status'
 }
 
 # MAIN

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -1,0 +1,17 @@
+
+function override_cdk_node_config_file(){
+    local __DATA_AVAILABILITY_MODE=$1
+    if [ -z $__DATA_AVAILABILITY_MODE ]; then
+        echo "Missing DATA_AVAILABILITY_MODE:override_cdk_node_config_file  ['rollup', 'cdk-validium', 'pessimistic']"
+        return 1
+    fi
+    echo "Override cdk config file"
+    local _FILENAME=$BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$__DATA_AVAILABILITY_MODE
+    cp $_FILENAME $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+    if [ $? -ne 0 ]; then
+        echo "... copying generic config file"
+        _FILENAME=$BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template
+        cp $_FILENAME $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+    fi
+    echo "Override cdk config using: " $_FILENAME
+}


### PR DESCRIPTION
## Description

CDK is expecting that **zkevm-ethtx-manager** library returns `ethtxmanager.ErrNotFound` but the library is not doing  that. It was fixed in library version 0.2.7
