### PR TITLE
fix: update Kurtosis CDK references and Docker images

### DIFF
--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -57,11 +57,11 @@ jobs:
         agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
     
     - name: Dump enclave logs
-      if: always()
+      if: failure()
       run: kurtosis dump ./dump
 
     - name: Generate archive name
-      if: always()
+      if: failure()
       run: |
         archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
         echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
@@ -69,7 +69,7 @@ jobs:
         kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
 
     - name: Upload logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  
   test-e2e-multi_pp:
     strategy:
       fail-fast: false
@@ -38,7 +39,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.3.3
+        ref: main
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -56,11 +56,11 @@ jobs:
         agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
     
     - name: Dump enclave logs
-      if: failure()
+      if: always()
       run: kurtosis dump ./dump
 
     - name: Generate archive name
-      if: failure()
+      if: always()
       run: |
         archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
         echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
@@ -68,7 +68,7 @@ jobs:
         kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
 
     - name: Upload logs
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: main
+        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-multi_pp.yml
+++ b/.github/workflows/test-e2e-multi_pp.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.31
+        ref: v0.3.3
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-pp.yml
+++ b/.github/workflows/test-e2e-pp.yml
@@ -87,11 +87,11 @@ jobs:
 
     
     - name: Dump enclave logs
-      if: always()
+      if: failure()
       run: kurtosis dump ./dump
 
     - name: Generate archive name
-      if: always()
+      if: failure()
       run: |
         archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
         echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
@@ -99,7 +99,7 @@ jobs:
         kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
 
     - name: Upload logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/test-e2e-pp.yml
+++ b/.github/workflows/test-e2e-pp.yml
@@ -1,4 +1,4 @@
-name: Test e2e
+name: Test e2e pp
 on: 
   push:
     branches:
@@ -38,10 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         e2e-group:
-          - "fork9-validium"
-          - "fork11-rollup"
-          - "fork12-validium"
-          - "fork12-rollup"
+          - "fork12-pessimistic"
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/.github/workflows/test-e2e-pp.yml
+++ b/.github/workflows/test-e2e-pp.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.3.3
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-pp.yml
+++ b/.github/workflows/test-e2e-pp.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
+        ref: v0.2.31
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e-pp.yml
+++ b/.github/workflows/test-e2e-pp.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.31
+        ref: cb8e973dd11d030e06920822fec9c337be8c24f9
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -91,11 +91,11 @@ jobs:
 
     
     - name: Dump enclave logs
-      if: failure()
+      if: always()
       run: kurtosis dump ./dump
 
     - name: Generate archive name
-      if: failure()
+      if: always()
       run: |
         archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
         echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
@@ -103,7 +103,7 @@ jobs:
         kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
 
     - name: Upload logs
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -90,11 +90,11 @@ jobs:
 
     
     - name: Dump enclave logs
-      if: always()
+      if: failure()
       run: kurtosis dump ./dump
 
     - name: Generate archive name
-      if: always()
+      if: failure()
       run: |
         archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
         echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
@@ -102,7 +102,7 @@ jobs:
         kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
 
     - name: Upload logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: 0xPolygon/kurtosis-cdk
         path: kurtosis-cdk
-        ref: v0.2.31
+        ref: v0.3.3
     
     - name: Install Kurtosis CDK tools
       uses: ./kurtosis-cdk/.github/actions/setup-kurtosis-cdk

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -1,9 +1,8 @@
 deployment_stages:
   deploy_l2_contracts: true
+  deploy_agglayer: false
 
 args:
-  verbosity: debug
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-hotfix.2-fork.11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -2,14 +2,13 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
+  verbosity: debug
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
-  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-hotfix.2-fork.11
+  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11
   cdk_node_image: cdk:latest
   gas_token_enabled: true
   gas_token_address: ""
   consensus_contract_type: rollup
   sequencer_type: erigon
-  # This is just a workaround, since the Kurtosis is deploying the agglayer even in the FEP setup
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork11-rollup.yml
+++ b/test/combinations/fork11-rollup.yml
@@ -1,9 +1,9 @@
 deployment_stages:
   deploy_l2_contracts: true
-  deploy_agglayer: false
 
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11-patch.1
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-hotfix.2-fork.11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11
   cdk_node_image: cdk:latest

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -2,13 +2,10 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   cdk_node_image: cdk:latest
   gas_token_enabled: true
   gas_token_address: ""
   consensus_contract_type: cdk-validium
   sequencer_type: erigon
-  # This is just a workaround, since the Kurtosis is deploying the agglayer even in the FEP setup
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -1,6 +1,5 @@
 deployment_stages:
   deploy_l2_contracts: true
-  deploy_agglayer: false
 
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12

--- a/test/combinations/fork12-cdk-validium.yml
+++ b/test/combinations/fork12-cdk-validium.yml
@@ -1,5 +1,6 @@
 deployment_stages:
   deploy_l2_contracts: true
+  deploy_agglayer: false
 
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -26,7 +26,8 @@ args:
   zkevm_l2_proofsigner_private_key: "0xc7fe3a006d75ba9326d9792523385abb49057c66aee0b8b4248821a89713f975"
 
   cdk_node_image: cdk:latest
-  zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
@@ -34,3 +35,4 @@ args:
   gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
+  verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -26,7 +26,7 @@ args:
   zkevm_l2_proofsigner_private_key: "0xc7fe3a006d75ba9326d9792523385abb49057c66aee0b8b4248821a89713f975"
 
   cdk_node_image: cdk:latest
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
+++ b/test/combinations/fork12-pessimistic-multi-attach-second-cdk.yml
@@ -25,9 +25,7 @@ args:
   zkevm_l2_proofsigner_address: "0xf1a661D7b601Ec46a040f57193cC99aB8c4132FA"
   zkevm_l2_proofsigner_private_key: "0xc7fe3a006d75ba9326d9792523385abb49057c66aee0b8b4248821a89713f975"
 
-
   cdk_node_image: cdk:latest
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
@@ -36,5 +34,3 @@ args:
   gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
-  verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
-

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,7 +1,9 @@
+deployment_stages:
+  deploy_l2_contracts: true
+
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:main
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
@@ -10,8 +12,5 @@ args:
   gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
-  verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}
-
-
-
+  agglayer_prover_sp1_key: ""
+  agglayer_prover_primary_prover: mock-prover

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,7 +1,7 @@
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
+  #agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,8 +1,9 @@
 args:
+  verbosity: debug
   cdk_node_image: cdk:latest
-  #agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-hotfix2
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -1,10 +1,8 @@
-deployment_stages:
-  deploy_l2_contracts: true
-
 args:
   cdk_node_image: cdk:latest
-  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
-  zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.9-RC1
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
@@ -12,5 +10,5 @@ args:
   gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
-  agglayer_prover_sp1_key: ""
-  agglayer_prover_primary_prover: mock-prover
+  verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
+  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork12-pessimistic-multi.yml
+++ b/test/combinations/fork12-pessimistic-multi.yml
@@ -4,7 +4,7 @@ deployment_stages:
 args:
   cdk_node_image: cdk:latest
   agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -2,7 +2,6 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   cdk_node_image: cdk:latest

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -3,7 +3,7 @@ deployment_stages:
 
 args:
   cdk_node_image: cdk:latest
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
   agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   additional_services: []

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,11 +1,11 @@
-deployment_stages:
-  deploy_l2_contracts: true
-
 args:
-  cdk_node_image: cdk:latest
-  zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
   agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  cdk_node_image: cdk:latest
+  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC5
+  zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
@@ -14,5 +14,4 @@ args:
   gas_token_address: ""
   zkevm_use_real_verifier: false
   enable_normalcy: true
-  agglayer_prover_sp1_key: ""
-  agglayer_prover_primary_prover: mock-prover
+  verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,11 +1,11 @@
+deployment_stages:
+  deploy_l2_contracts: true
+
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer:main
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   cdk_node_image: cdk:latest
-  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC5
-  zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
@@ -14,5 +14,5 @@ args:
   gas_token_address: ""
   zkevm_use_real_verifier: false
   enable_normalcy: true
-  verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea
-  
+  agglayer_prover_sp1_key: ""
+  agglayer_prover_primary_prover: mock-prover

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -1,17 +1,18 @@
 args:
-  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  verbosity: debug
   cdk_node_image: cdk:latest
-  zkevm_bridge_proxy_image: haproxy:3.1-bookworm
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC5
-  zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.16-hotfix2
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
   gas_token_enabled: true
-  gas_token_address: ""
+  gas_token_address: ''
   zkevm_use_real_verifier: false
+  agglayer_prover_primary_prover: mock-prover
   enable_normalcy: true
+  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}
   verifier_program_vkey: 0x00766aa16a6efe4ac05c0fe21d4b50f9631dbd1a2663a982da861427085ea2ea

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -2,9 +2,10 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   cdk_node_image: cdk:latest
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.5-pp-fork.12
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/test/combinations/fork12-pessimistic.yml
+++ b/test/combinations/fork12-pessimistic.yml
@@ -4,7 +4,7 @@ deployment_stages:
 args:
   cdk_node_image: cdk:latest
   zkevm_contracts_image: leovct/zkevm-contracts:9228886-fork.13
-  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.5
+  agglayer_image: ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   additional_services: []
   consensus_contract_type: pessimistic

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -1,6 +1,5 @@
 deployment_stages:
   deploy_l2_contracts: true
-  deploy_agglayer: false
 
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -2,12 +2,11 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12-patch.1
+  verbosity: debug
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.61.14-RC1-amd64
   cdk_node_image: cdk:latest
   gas_token_enabled: true
   gas_token_address: ""
   consensus_contract_type: rollup
   sequencer_type: erigon
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork12-rollup.yml
+++ b/test/combinations/fork12-rollup.yml
@@ -1,8 +1,8 @@
 deployment_stages:
   deploy_l2_contracts: true
+  deploy_agglayer: false
 
 args:
-  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.6-pp-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   cdk_node_image: cdk:latest

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -1,9 +1,8 @@
 deployment_stages:
   deploy_l2_contracts: true
+  deploy_agglayer: false
 
 args:
-  verbosity: debug
-  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -2,10 +2,11 @@ deployment_stages:
   deploy_l2_contracts: true
 
 args:
+  verbosity: debug
   agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
-  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
+  zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   consensus_contract_type: cdk-validium
   cdk_node_image: cdk:latest
@@ -13,6 +14,3 @@ args:
   gas_token_address: ""
   additional_services:
     - pless_zkevm_node
-  sequencer_type: erigon
-  # This is just a workaround, since the Kurtosis is deploying the agglayer even in the FEP setup
-  agglayer_prover_sp1_key: {{.agglayer_prover_sp1_key}}

--- a/test/combinations/fork9-cdk-validium.yml
+++ b/test/combinations/fork9-cdk-validium.yml
@@ -1,9 +1,9 @@
 deployment_stages:
   deploy_l2_contracts: true
-  deploy_agglayer: false
 
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9-patch.1
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.19
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -1,7 +1,7 @@
 PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-AggLayerURL="{{.agglayer_url}}"
+AggLayerURL="{{.agglayer_readrpc_url}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -1,7 +1,7 @@
 PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-AggLayerURL="{{.agglayer_port}}"
+AggLayerURL="http://agglayer:{{.agglayer_port}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}

--- a/test/config/kurtosis-cdk-node-config.toml.template
+++ b/test/config/kurtosis-cdk-node-config.toml.template
@@ -1,7 +1,7 @@
 PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-AggLayerURL="{{.agglayer_readrpc_url}}"
+AggLayerURL="{{.agglayer_port}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}

--- a/test/config/kurtosis-cdk-node-config.toml.template.pessimistic
+++ b/test/config/kurtosis-cdk-node-config.toml.template.pessimistic
@@ -1,7 +1,7 @@
 PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-AggLayerURL="{{.agglayer_readrpc_url}}"
+AggLayerURL="http://agglayer:{{.agglayer_port}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}

--- a/test/config/kurtosis-cdk-node-config.toml.template.pessimistic
+++ b/test/config/kurtosis-cdk-node-config.toml.template.pessimistic
@@ -1,7 +1,7 @@
 PathRWData = "{{.zkevm_path_rw_data}}/"
 L1URL="{{.l1_rpc_url}}"
 L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-AggLayerURL="http://agglayer:{{.agglayer_port}}"
+AggLayerURL="{{.agglayer_url}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
 IsValidiumMode = {{.is_cdk_validium}}
@@ -25,6 +25,8 @@ AggregatorPrivateKeyPassword  = "{{.zkevm_l2_keystore_password}}"
 SenderProofToL1Addr = "{{.zkevm_l2_agglayer_address}}"   
 polygonBridgeAddr = "{{.zkevm_bridge_address}}" 
 
+
+RPCURL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 WitnessURL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 
 

--- a/test/run-e2e-multi_pp.sh
+++ b/test/run-e2e-multi_pp.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source $(dirname $0)/scripts/env.sh
+source $(dirname $0)/scripts/shared.sh
 
 function log_error() {
     echo -e "\033[0;31mError: $*" "\033[0m"
@@ -43,13 +44,7 @@ function resolve_template(){
     eval $_RESULT_VARNAME="$_TEMP_FILE"
 }
 
-function override_cdk_node_config_file(){
-    echo "Override cdk config file"
-    cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$DATA_AVAILABILITY_MODE $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
-    if [ $? -ne 0 ]; then
-        cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
-    fi
-}
+
 
 ###############################################################################
 # MAIN

--- a/test/run-e2e-multi_pp.sh
+++ b/test/run-e2e-multi_pp.sh
@@ -65,7 +65,8 @@ build_docker_if_required
 resolve_template $PP1_ORIGIN_CONFIG_FILE PP1_RENDERED_CONFIG_FILE
 resolve_template $PP2_ORIGIN_CONFIG_FILE PP2_RENDERED_CONFIG_FILE
 
-override_cdk_node_config_file
+override_cdk_node_config_file pessimistic
+ok_or_fatal "Failed to override cdk node config file"
 
 kurtosis clean --all
 kurtosis run --enclave $KURTOSIS_ENCLAVE --args-file "$PP1_RENDERED_CONFIG_FILE" --image-download always $KURTOSIS_FOLDER

--- a/test/run-e2e-multi_pp.sh
+++ b/test/run-e2e-multi_pp.sh
@@ -43,6 +43,14 @@ function resolve_template(){
     eval $_RESULT_VARNAME="$_TEMP_FILE"
 }
 
+function override_cdk_node_config_file(){
+    echo "Override cdk config file"
+    cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$DATA_AVAILABILITY_MODE $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+    if [ $? -ne 0 ]; then
+        cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+    fi
+}
+
 ###############################################################################
 # MAIN
 ###############################################################################
@@ -61,6 +69,8 @@ KURTOSIS_ENCLAVE=cdk
 build_docker_if_required
 resolve_template $PP1_ORIGIN_CONFIG_FILE PP1_RENDERED_CONFIG_FILE
 resolve_template $PP2_ORIGIN_CONFIG_FILE PP2_RENDERED_CONFIG_FILE
+
+override_cdk_node_config_file
 
 kurtosis clean --all
 kurtosis run --enclave $KURTOSIS_ENCLAVE --args-file "$PP1_RENDERED_CONFIG_FILE" --image-download always $KURTOSIS_FOLDER

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -26,7 +26,7 @@ else
 fi
 
 kurtosis clean --all
-override_cdk_node_config_file  $DATA_AVAILABILITY_MODE
+override_cdk_node_config_file $DATA_AVAILABILITY_MODE
 
 KURTOSIS_CONFIG_FILE="combinations/$FORK-$DATA_AVAILABILITY_MODE.yml"
 TEMP_CONFIG_FILE=$(mktemp --suffix ".yml")

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -26,7 +26,13 @@ fi
 
 kurtosis clean --all
 echo "Override cdk config file"
-cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$DATA_AVAILABILITY_MODE $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+if [ $? -ne 0 ]; then
+    echo "... copying generic config file"
+    cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+fi
+
+
 KURTOSIS_CONFIG_FILE="combinations/$FORK-$DATA_AVAILABILITY_MODE.yml"
 TEMP_CONFIG_FILE=$(mktemp --suffix ".yml")
 echo "rendering $KURTOSIS_CONFIG_FILE to temp file $TEMP_CONFIG_FILE"

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source $(dirname $0)/scripts/env.sh
+source $(dirname $0)/scripts/shared.sh
 
 FORK=$1
 if [ -z $FORK ]; then
@@ -25,13 +26,7 @@ else
 fi
 
 kurtosis clean --all
-echo "Override cdk config file"
-cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$DATA_AVAILABILITY_MODE $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
-if [ $? -ne 0 ]; then
-    echo "... copying generic config file"
-    cp $BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
-fi
-
+override_cdk_node_config_file  $DATA_AVAILABILITY_MODE
 
 KURTOSIS_CONFIG_FILE="combinations/$FORK-$DATA_AVAILABILITY_MODE.yml"
 TEMP_CONFIG_FILE=$(mktemp --suffix ".yml")

--- a/test/scripts/agglayer_certificates_monitor.sh
+++ b/test/scripts/agglayer_certificates_monitor.sh
@@ -28,12 +28,18 @@ function check_timeout() {
 }
 
 function check_num_certificates() {
-    readonly agglayer_rpc_url="$(kurtosis port print cdk agglayer aglr-readrpc)"
+    agglayer_rpc_url="$(kurtosis port print cdk agglayer aglr-readrpc)"
+    if [ $? -ne 0 ]; then
+        agglayer_rpc_url="$(kurtosis port print cdk agglayer agglayer)"
+        if [ $? -ne 0 ]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] Error getting agglayer rpc url (not aglr-readrpc or agglayer)." >&3
+        fi
+    fi
 
     cast_output=$(cast rpc --rpc-url "$agglayer_rpc_url" "interop_getLatestKnownCertificateHeader" "$l2_rpc_network_id" 2>&1)
 
     if [ $? -ne 0 ]; then
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Error executing command cast rpc: $cast_output"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Error executing command cast rpc $agglayer_rpc_url: $cast_output"
         return
     fi
 

--- a/test/scripts/agglayer_certificates_monitor.sh
+++ b/test/scripts/agglayer_certificates_monitor.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # This script monitors the agglayer certificates progress of pessimistic proof.
 
-function parse_params(){
+function parse_params() {
     # Check if the required arguments are provided.
     if [ "$#" -lt 3 ]; then
-    echo "Usage: $0 <settle_certificates_target> <timeout> <l2_network_id>"
-    exit 1
+        echo "Usage: $0 <settle_certificates_target> <timeout> <l2_network_id>"
+        exit 1
     fi
 
     # The number of batches to be verified.
@@ -18,7 +18,7 @@ function parse_params(){
     l2_rpc_network_id="$3"
 }
 
-function check_timeout(){
+function check_timeout() {
     local _end_time=$1
     current_time=$(date +%s)
     if ((current_time > _end_time)); then
@@ -27,8 +27,8 @@ function check_timeout(){
     fi
 }
 
-function check_num_certificates(){
-    readonly agglayer_rpc_url="$(kurtosis port print cdk agglayer agglayer)"
+function check_num_certificates() {
+    readonly agglayer_rpc_url="$(kurtosis port print cdk agglayer aglr-readrpc)"
 
     cast_output=$(cast rpc --rpc-url "$agglayer_rpc_url" "interop_getLatestKnownCertificateHeader" "$l2_rpc_network_id" 2>&1)
 
@@ -51,17 +51,17 @@ function check_num_certificates(){
 
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Last known agglayer certificate height: $height, status: $status" >&3
 
-    if (( height > settle_certificates_target - 1 )); then
+    if ((height > settle_certificates_target - 1)); then
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Success! The number of settled certificates has reached the target." >&3
         exit 0
     fi
 
-    if (( height == settle_certificates_target - 1 )); then
+    if ((height == settle_certificates_target - 1)); then
         if [ "$status" == "Settled" ]; then
             echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Success! The number of settled certificates has reached the target." >&3
             exit 0
         fi
-        
+
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] ⚠️ Warning! The number of settled certificates is one less than the target." >&3
     fi
 }
@@ -73,7 +73,7 @@ function extract_certificate_height() {
 
 function extract_certificate_status() {
     local cast_output="$1"
-     echo "$cast_output" | jq -r '.status'
+    echo "$cast_output" | jq -r '.status'
 }
 
 # MAIN

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -1,6 +1,10 @@
 
 function override_cdk_node_config_file(){
     local __DATA_AVAILABILITY_MODE=$1
+    if [ -z $__DATA_AVAILABILITY_MODE ]; then
+        echo "Missing DATA_AVAILABILITY_MODE:override_cdk_node_config_file  ['rollup', 'cdk-validium', 'pessimistic']"
+        return 1
+    fi
     echo "Override cdk config file"
     local _FILENAME=$BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$__DATA_AVAILABILITY_MODE
     cp $_FILENAME $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -1,0 +1,13 @@
+
+function override_cdk_node_config_file(){
+    local __DATA_AVAILABILITY_MODE=$1
+    echo "Override cdk config file"
+    local _FILENAME=$BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template.$__DATA_AVAILABILITY_MODE
+    cp $_FILENAME $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+    if [ $? -ne 0 ]; then
+        echo "... copying generic config file"
+        _FILENAME=$BASE_FOLDER/config/kurtosis-cdk-node-config.toml.template
+        cp $_FILENAME $KURTOSIS_FOLDER/templates/trusted-node/cdk-node-config.toml
+    fi
+    echo "Override cdk config using: " $_FILENAME
+}


### PR DESCRIPTION
## Description

Currently the e2e from branch release/v0.5.x are failing due kurtosis-cdk changes. This PR fix it.

The FEP and PP are splitted to reduce the complexity of pass both of them with same combination of agglayer + kurtosis_cdk
