### PR TITLE
Fix bad l1infotree counter in sequenceBatchesValidium SC call

### DIFF
--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -214,7 +214,13 @@ func (s *SequenceSender) populateSequenceData(rpcBatch *types.RPCBatch, batchNum
 	}
 
 	if len(batchRaw.Blocks) > 0 {
-		rpcBatch.SetL1InfoTreeIndex(batchRaw.Blocks[len(batchRaw.Blocks)-1].IndexL1InfoTree)
+		maxIndex := uint32(0)
+		for _, block := range batchRaw.Blocks {
+			if block.IndexL1InfoTree > maxIndex {
+				maxIndex = block.IndexL1InfoTree
+			}
+		}
+		rpcBatch.SetL1InfoTreeIndex(maxIndex)
 	}
 
 	s.sequenceData[batchNumber] = &sequenceData{


### PR DESCRIPTION
## Description
Instead of getting max `IindexL1InfoTree`  it get the last one (code [here](https://github.com/0xPolygon/cdk/blob/5098172e30a2f701ebed471d49d4593aad8c918b/sequencesender/sequencesender.go#L217))
- The [function](https://github.com/0xPolygon/cdk/blob/5098172e30a2f701ebed471d49d4593aad8c918b/sequencesender/txbuilder/banana_base.go#L90) that choose the L1infoRoot do:
   - Get the last l1infoindex for finalizedBlock
   - Check against the index of  batchL2data (that is worng)

So can choose a index lower that the one inside the batchl2data



Fixes #314
