### PR TITLE
ci: updated e2e ref

### DIFF
--- a/.github/test_fork12_cdk_validium_e2e_args.json
+++ b/.github/test_fork12_cdk_validium_e2e_args.json
@@ -12,6 +12,7 @@
     "consensus_contract_type": "cdk_validium",
     "sequencer_type": "erigon",
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta6-tmp-bridge",
-    "aggkit_components": "bridge"
+    "aggkit_components": "bridge",
+    "enable_aggkit_claim_sponsor": true
   }
 }

--- a/.github/test_fork12_cdk_validium_e2e_args.json
+++ b/.github/test_fork12_cdk_validium_e2e_args.json
@@ -11,7 +11,7 @@
     "gas_token_address": "",
     "consensus_contract_type": "cdk_validium",
     "sequencer_type": "erigon",
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta5-tmp-bridge",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta6-tmp-bridge",
     "aggkit_components": "bridge"
   }
 }

--- a/.github/test_fork12_rollup_e2e_args.json
+++ b/.github/test_fork12_rollup_e2e_args.json
@@ -11,7 +11,7 @@
     "gas_token_address": "",
     "consensus_contract_type": "rollup",
     "sequencer_type": "erigon",
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta5-tmp-bridge",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta6-tmp-bridge",
     "aggkit_components": "bridge"
   }
 }

--- a/.github/test_fork12_rollup_e2e_args.json
+++ b/.github/test_fork12_rollup_e2e_args.json
@@ -12,6 +12,7 @@
     "consensus_contract_type": "rollup",
     "sequencer_type": "erigon",
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta6-tmp-bridge",
-    "aggkit_components": "bridge"
+    "aggkit_components": "bridge",
+    "enable_aggkit_claim_sponsor": true
   }
 }

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,7 +66,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
@@ -89,7 +89,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
@@ -112,7 +112,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
@@ -135,7 +135,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,7 +66,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
@@ -89,7 +89,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
@@ -112,7 +112,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
@@ -135,7 +135,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -63,11 +63,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 04c5388815d4bf9a8534eb495949392366e8c4f3
-      agglayer-e2e-ref: f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
+      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
 
@@ -86,11 +86,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 04c5388815d4bf9a8534eb495949392366e8c4f3
-      agglayer-e2e-ref: f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
+      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
 
@@ -109,11 +109,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 04c5388815d4bf9a8534eb495949392366e8c4f3
-      agglayer-e2e-ref: f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
+      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
 
@@ -132,11 +132,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 04c5388815d4bf9a8534eb495949392366e8c4f3
-      agglayer-e2e-ref: f3b4b1afdb684ef68f2149f849b2cc84d73261c9
+      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
+      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,7 +66,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
+      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
@@ -89,7 +89,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
+      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
@@ -112,7 +112,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
+      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
@@ -135,7 +135,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: f93139b58848c9f12b5174e2d7823414f33de9dc
+      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
       agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -63,11 +63,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
-      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
+      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
 
@@ -86,11 +86,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
-      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
+      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
 
@@ -109,11 +109,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
-      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
+      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
 
@@ -132,11 +132,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: c77b78ba89346ad888325a4c83381260ebec9077
-      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
+      kurtosis-cdk-ref: c5de54d2080673f48f8fa727d2b3999f4b1262cc
+      agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,7 +66,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
+      kurtosis-cdk-ref: 96df9ddd83df24b4efee43b372d9a3902079d5f3
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
@@ -89,7 +89,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
+      kurtosis-cdk-ref: 96df9ddd83df24b4efee43b372d9a3902079d5f3
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
@@ -112,7 +112,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
+      kurtosis-cdk-ref: 96df9ddd83df24b4efee43b372d9a3902079d5f3
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
@@ -135,7 +135,7 @@ jobs:
     uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@d5b04cec05a949d93a5e893ce43be2e04c1b5249
     secrets: inherit
     with:
-      kurtosis-cdk-ref: ede0cd684b5d9ea00a1277ea0a1b88b796ae1e51
+      kurtosis-cdk-ref: 96df9ddd83df24b4efee43b372d9a3902079d5f3
       agglayer-e2e-ref: d5b04cec05a949d93a5e893ce43be2e04c1b5249
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -63,11 +63,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
-      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork9-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork9-cdk-validium-e2e-args }}
 
@@ -86,11 +86,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
-      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork11-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork11-rollup-e2e-args }}
 
@@ -109,11 +109,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
-      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork12-cdk-validium-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-cdk-validium-e2e-args }}
 
@@ -132,11 +132,11 @@ jobs:
     needs:
       - build-cdk-image
       - read-test-args
-    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+    uses: agglayer/e2e/.github/workflows/cdk-e2e.yml@0503bac3ccdeecc7173863176dff540723761453
     secrets: inherit
     with:
-      kurtosis-cdk-ref: 0a96ae24c96a2228c9c4304695341bf4ff9eb02a
-      agglayer-e2e-ref: df0b54fc6612f639b488ed9b1f63eb7fe8e5d4f5
+      kurtosis-cdk-ref: 99a912e78954ef495c8339e78c2f4c2a202f941d
+      agglayer-e2e-ref: 0503bac3ccdeecc7173863176dff540723761453
       test-name: test-fork12-rollup-e2e
       kurtosis-cdk-args: ${{ needs.read-test-args.outputs.test-fork12-rollup-e2e-args }}
 


### PR DESCRIPTION
## Description

1. Updates commit hash of kurtosis and e2e repo.
2. Update config file to pass enable_aggkit_claim_sponsor to start claim sponsor.
