### PR TITLE
refactor: simplify argument handling in run-local-e2e script

### DIFF
--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 log_info() {
     echo -e "${GREEN}[INFO]${NC} $*" | tee -a "$LOG_FILE"
@@ -16,15 +16,14 @@ log_error() {
 
 trap 'log_error "Script failed at line $LINENO"' ERR
 
-if [ "$#" -ne 4 ]; then
-    echo "Usage: $0 <test_type: fork9-cdk-validium | fork11-rollup | fork12-cdk-validium | fork12-rollup> <path/to/kurtosis-cdk/repo> <path/to/e2e/repo> <run_tests: true | false>"
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <test_type> <path/to/kurtosis-cdk/repo> [<path/to/e2e/repo>]"
     exit 1
 fi
 
 TEST_TYPE=$1
 KURTOSIS_FOLDER=$2
-E2E_FOLDER=$3
-RUN_TESTS=$4
+E2E_FOLDER=${3:-""}
 
 PROJECT_ROOT="$PWD"
 ROOT_FOLDER="/tmp/cdk-e2e-run"
@@ -38,7 +37,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 
 log_info "Starting local E2E setup..."
 
-# Build cdk Docker Image if it doesn't exist
+# Build docker image if needed
 if [ "$(docker images -q cdk:local | wc -l)" -eq 0 ]; then
     log_info "Building cdk:local docker image..."
     pushd "$PROJECT_ROOT" > /dev/null
@@ -48,40 +47,43 @@ else
     log_info "Docker image cdk:local already exists."
 fi
 
-log_info "Using provided Kurtosis CDK repo at: $KURTOSIS_FOLDER"
-
+log_info "Using Kurtosis CDK repo: $KURTOSIS_FOLDER"
 pushd "$KURTOSIS_FOLDER" > /dev/null
+
 log_info "Cleaning any existing Kurtosis enclaves..."
 kurtosis clean --all
 
 ENCLAVE="cdk"
-
-# Start Kurtosis Enclave 
 log_info "Starting Kurtosis enclave"
 
-if [ "$TEST_TYPE" == "fork9-cdk-validium" ]; then
-    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork9_cdk_validium_e2e_args.json" .
-elif [ "$TEST_TYPE" == "fork11-rollup" ]; then
-    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork11_rollup_e2e_args.json" .
-elif [ "$TEST_TYPE" == "fork12-cdk-validium" ]; then
-    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_cdk_validium_e2e_args.json" .
-elif [ "$TEST_TYPE" == "fork12-rollup" ]; then
-    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_rollup_e2e_args.json" .
-else
-    log_error "Unknown test type: $TEST_TYPE"
-    exit 1
-fi
+case "$TEST_TYPE" in
+    fork9-cdk-validium)
+        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork9_cdk_validium_e2e_args.json" .
+        ;;
+    fork11-rollup)
+        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork11_rollup_e2e_args.json" .
+        ;;
+    fork12-cdk-validium)
+        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_cdk_validium_e2e_args.json" .
+        ;;
+    fork12-rollup)
+        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_rollup_e2e_args.json" .
+        ;;
+    *)
+        log_error "Unknown test type: $TEST_TYPE"
+        exit 1
+        ;;
+esac
 
 log_info "$ENCLAVE enclave started successfully."
 popd > /dev/null
 
-if [ "$RUN_TESTS" == "true" ]; then
-    log_info "Using provided Agglayer E2E repo at: $E2E_FOLDER"
-
+# Run tests if E2E_FOLDER is provided
+if [ -n "$E2E_FOLDER" ]; then
+    log_info "Running E2E tests using: $E2E_FOLDER"
     pushd "$E2E_FOLDER" > /dev/null
 
-    # Setup environment
-    log_info "Setting up e2e environment..."
+    log_info "Setting up E2E environment..."
     set -a
     source ./tests/.env
     set +a
@@ -93,6 +95,7 @@ if [ "$RUN_TESTS" == "true" ]; then
 
     log_info "Running BATS E2E tests..."
     bats tests/cdk/access-list-e2e.bats tests/cdk/basic-e2e.bats tests/cdk/e2e.bats
+
     if [[ "$TEST_TYPE" == "fork9-cdk-validium" || "$TEST_TYPE" == "fork11-rollup" ]]; then
         bats tests/cdk/bridge-e2e.bats
     elif [[ "$TEST_TYPE" == "fork12-cdk-validium" || "$TEST_TYPE" == "fork12-rollup" ]]; then
@@ -100,8 +103,8 @@ if [ "$RUN_TESTS" == "true" ]; then
     fi
 
     popd > /dev/null
-    log_info "E2E tests executed. Logs saved to $LOG_FILE"
+    log_info "E2E tests completed. Logs saved to $LOG_FILE"
 else
-    log_info "Skipping tests as per user request."
+    log_info "No E2E repo provided. Skipping tests."
     exit 0
 fi

--- a/test/run-local-e2e.sh
+++ b/test/run-local-e2e.sh
@@ -17,7 +17,7 @@ log_error() {
 trap 'log_error "Script failed at line $LINENO"' ERR
 
 if [ "$#" -lt 2 ]; then
-    echo "Usage: $0 <test_type> <path/to/kurtosis-cdk/repo> [<path/to/e2e/repo>]"
+    echo "Usage: $0 <test_type: fork9-cdk-validium | fork11-rollup | fork12-cdk-validium | fork12-rollup> <path/to/kurtosis-cdk/repo> [<path/to/e2e/repo>]"
     exit 1
 fi
 
@@ -40,15 +40,15 @@ log_info "Starting local E2E setup..."
 # Build docker image if needed
 if [ "$(docker images -q cdk:local | wc -l)" -eq 0 ]; then
     log_info "Building cdk:local docker image..."
-    pushd "$PROJECT_ROOT" > /dev/null
+    pushd "$PROJECT_ROOT" >/dev/null
     make build-docker
-    popd > /dev/null
+    popd >/dev/null
 else
     log_info "Docker image cdk:local already exists."
 fi
 
 log_info "Using Kurtosis CDK repo: $KURTOSIS_FOLDER"
-pushd "$KURTOSIS_FOLDER" > /dev/null
+pushd "$KURTOSIS_FOLDER" >/dev/null
 
 log_info "Cleaning any existing Kurtosis enclaves..."
 kurtosis clean --all
@@ -57,31 +57,31 @@ ENCLAVE="cdk"
 log_info "Starting Kurtosis enclave"
 
 case "$TEST_TYPE" in
-    fork9-cdk-validium)
-        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork9_cdk_validium_e2e_args.json" .
-        ;;
-    fork11-rollup)
-        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork11_rollup_e2e_args.json" .
-        ;;
-    fork12-cdk-validium)
-        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_cdk_validium_e2e_args.json" .
-        ;;
-    fork12-rollup)
-        kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_rollup_e2e_args.json" .
-        ;;
-    *)
-        log_error "Unknown test type: $TEST_TYPE"
-        exit 1
-        ;;
+fork9-cdk-validium)
+    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork9_cdk_validium_e2e_args.json" .
+    ;;
+fork11-rollup)
+    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork11_rollup_e2e_args.json" .
+    ;;
+fork12-cdk-validium)
+    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_cdk_validium_e2e_args.json" .
+    ;;
+fork12-rollup)
+    kurtosis run --enclave "$ENCLAVE" --args-file "$PROJECT_ROOT/.github/test_fork12_rollup_e2e_args.json" .
+    ;;
+*)
+    log_error "Unknown test type: $TEST_TYPE"
+    exit 1
+    ;;
 esac
 
 log_info "$ENCLAVE enclave started successfully."
-popd > /dev/null
+popd >/dev/null
 
 # Run tests if E2E_FOLDER is provided
 if [ -n "$E2E_FOLDER" ]; then
     log_info "Running E2E tests using: $E2E_FOLDER"
-    pushd "$E2E_FOLDER" > /dev/null
+    pushd "$E2E_FOLDER" >/dev/null
 
     log_info "Setting up E2E environment..."
     set -a
@@ -102,7 +102,7 @@ if [ -n "$E2E_FOLDER" ]; then
         bats tests/aggkit/bridge-e2e.bats tests/aggkit/bridge-e2e-custom-gas.bats
     fi
 
-    popd > /dev/null
+    popd >/dev/null
     log_info "E2E tests completed. Logs saved to $LOG_FILE"
 else
     log_info "No E2E repo provided. Skipping tests."


### PR DESCRIPTION
## Description

The PR simplifies the running of local kurtosis stack in the cdk, by making `E2E_FOLDER` arg optional, and obsoleting `RUN_TESTS` parameter, as it is redundant. In case `E2E_FOLDER` is non empty, it means the tests should be run (otherwise they are skipped).

Fixes #350
