### PR TITLE
fix: update toBlock and add CreatedAt when setting MaxCertSize

### DIFF
--- a/aggsender/aggsender.go
+++ b/aggsender/aggsender.go
@@ -270,7 +270,7 @@ func (a *AggSender) sendCertificate(ctx context.Context) (*agglayer.SignedCertif
 		NewLocalExitRoot:      certificate.NewLocalExitRoot,
 		PreviousLocalExitRoot: &prevLER,
 		FromBlock:             fromBlock,
-		ToBlock:               toBlock,
+		ToBlock:               certificateParams.ToBlock,
 		CreatedAt:             certificateParams.CreatedAt,
 		UpdatedAt:             certificateParams.CreatedAt,
 		SignedCertificate:     string(raw),

--- a/aggsender/types/certificate_build_params.go
+++ b/aggsender/types/certificate_build_params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/cdk/bridgesync"
 )
@@ -39,6 +40,7 @@ func (c *CertificateBuildParams) Range(fromBlock, toBlock uint64) (*CertificateB
 		ToBlock:   toBlock,
 		Bridges:   make([]bridgesync.Bridge, 0),
 		Claims:    make([]bridgesync.Claim, 0),
+		CreatedAt: uint32(time.Now().UTC().Unix()),
 	}
 
 	for _, bridge := range c.Bridges {

--- a/l1infotreesync/downloader.go
+++ b/l1infotreesync/downloader.go
@@ -157,6 +157,7 @@ func buildAppender(client EthClienter, globalExitRoot,
 			)
 		}
 		b.Events = append(b.Events, Event{VerifyBatches: &VerifyBatches{
+			BlockNumber:   l.BlockNumber,
 			BlockPosition: uint64(l.Index),
 			RollupID:      verifyBatches.RollupID,
 			NumBatch:      verifyBatches.NumBatch,
@@ -176,6 +177,7 @@ func buildAppender(client EthClienter, globalExitRoot,
 			)
 		}
 		b.Events = append(b.Events, Event{VerifyBatches: &VerifyBatches{
+			BlockNumber:   l.BlockNumber,
 			BlockPosition: uint64(l.Index),
 			RollupID:      verifyBatches.RollupID,
 			NumBatch:      verifyBatches.NumBatch,

--- a/l1infotreesync/processor_verifybatches.go
+++ b/l1infotreesync/processor_verifybatches.go
@@ -42,7 +42,6 @@ func (p *processor) processVerifyBatches(tx db.Txer, blockNumber uint64, event *
 		return fmt.Errorf("error rollupExitTree.UpsertLeaf. err: %w", err)
 	}
 	verifyBatches := event
-	verifyBatches.BlockNumber = blockNumber
 	verifyBatches.RollupExitRoot = newRoot
 	if err = meddler.Insert(tx, "verify_batches", verifyBatches); err != nil {
 		return fmt.Errorf("error inserting verify_batches. err: %w", err)


### PR DESCRIPTION
1. Fixes [issue](https://github.com/0xPolygon/cdk/issues/358)
2. add missing field `CreatedAt` when `MaxCertSize` is set to a non-zero value
3. set `BlockNumber` at the beginning
